### PR TITLE
Add checkstyle workflow action

### DIFF
--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -2,6 +2,11 @@ name: Checkstyle
 
 on: pull_request
 
+permissions:
+  checks: write
+  contents: read
+  pull-requests: read
+
 jobs:
   checkstyle_job:
     runs-on: ubuntu-latest

--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -13,7 +13,7 @@ jobs:
         uses: nikitasavinov/checkstyle-action@master
         with:
           level: error
-          reporter: 'github-pr-review'
+          reporter: 'github-pr-check'
           checkstyle_config: "/home/runner/work/chasm/chasm/config/checkstyle/checkstyle.xml"
           github_token: ${{ secrets.GITHUB_TOKEN }}
           fail_on_error: true

--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           level: error
           reporter: 'github-pr-check'
-          checkstyle_config: "/home/runner/work/chasm/chasm/config/checkstyle/checkstyle.xml"
+          checkstyle_config: '${{ github.workspace }}/config/checkstyle/checkstyle.xml'
           github_token: ${{ secrets.GITHUB_TOKEN }}
           fail_on_error: true
           checkstyle_version: 9.1

--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -1,0 +1,20 @@
+name: Checkstyle
+
+on: pull_request
+
+jobs:
+  checkstyle_job:
+    runs-on: ubuntu-latest
+    name: Checkstyle
+    steps:
+      - name: Checkout Branch
+        uses: actions/checkout@v2
+      - name: Run Checkstyle
+        uses: nikitasavinov/checkstyle-action@master
+        with:
+          level: error
+          reporter: 'github-pr-review'
+          checkstyle_config: "/home/runner/work/chasm/chasm/config/checkstyle/checkstyle.xml"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          fail_on_error: true
+          checkstyle_version: 9.1


### PR DESCRIPTION
This PR adds a GitHub workflow action that checks the style of new code in PRs, as mentioned in [#18](https://github.com/QuiltMC/chasm/issues/18#issuecomment-973109471) - using [nikitasavinov/checkstyle-action](https://github.com/nikitasavinov/checkstyle-action).

Here's how it looks in action (:wink:), on a testing repo:
![image](https://user-images.githubusercontent.com/88054819/143157376-c62c5cf1-8781-409c-868b-6eb266a3536a.png)
