### PR TITLE
Degenerify `ValueNode`

### DIFF
--- a/chasm-lang/src/main/java/org/quiltmc/chasm/lang/ChasmLangTransformer.java
+++ b/chasm-lang/src/main/java/org/quiltmc/chasm/lang/ChasmLangTransformer.java
@@ -140,7 +140,7 @@ public class ChasmLangTransformer implements Transformer {
             IntegerExpression start = (IntegerExpression) rawStart;
             IntegerExpression end = (IntegerExpression) rawEnd;
 
-            return new SliceTarget((ListNode) target.getNode(), start.getValue(), end.getValue());
+            return new SliceTarget(Node.asList(target.getNode()), start.getValue(), end.getValue());
         }
 
         throw new RuntimeException("Target mst be node or map.");

--- a/chasm-lang/src/main/java/org/quiltmc/chasm/lang/interop/ChasmBooleanNodeExpression.java
+++ b/chasm-lang/src/main/java/org/quiltmc/chasm/lang/interop/ChasmBooleanNodeExpression.java
@@ -4,15 +4,15 @@ import org.quiltmc.chasm.api.tree.ValueNode;
 import org.quiltmc.chasm.lang.ast.BooleanExpression;
 
 public class ChasmBooleanNodeExpression extends BooleanExpression implements ChasmNodeExpression {
-    private final ValueNode<Boolean> node;
+    private final ValueNode node;
 
-    public ChasmBooleanNodeExpression(ValueNode<Boolean> node) {
-        super(node.getValue());
+    public ChasmBooleanNodeExpression(ValueNode node) {
+        super(node.getValueAsBoolean());
         this.node = node;
     }
 
     @Override
-    public ValueNode<Boolean> getNode() {
+    public ValueNode getNode() {
         return node;
     }
 }

--- a/chasm-lang/src/main/java/org/quiltmc/chasm/lang/interop/ChasmIntegerNodeExpression.java
+++ b/chasm-lang/src/main/java/org/quiltmc/chasm/lang/interop/ChasmIntegerNodeExpression.java
@@ -4,15 +4,15 @@ import org.quiltmc.chasm.api.tree.ValueNode;
 import org.quiltmc.chasm.lang.ast.IntegerExpression;
 
 public class ChasmIntegerNodeExpression extends IntegerExpression implements ChasmNodeExpression {
-    private final ValueNode<Integer> node;
+    private final ValueNode node;
 
-    public ChasmIntegerNodeExpression(ValueNode<Integer> node) {
-        super(node.getValue());
+    public ChasmIntegerNodeExpression(ValueNode node) {
+        super(node.getValueAsInt());
         this.node = node;
     }
 
     @Override
-    public ValueNode<Integer> getNode() {
+    public ValueNode getNode() {
         return node;
     }
 }

--- a/chasm-lang/src/main/java/org/quiltmc/chasm/lang/interop/ChasmStringNodeExpression.java
+++ b/chasm-lang/src/main/java/org/quiltmc/chasm/lang/interop/ChasmStringNodeExpression.java
@@ -4,15 +4,15 @@ import org.quiltmc.chasm.api.tree.ValueNode;
 import org.quiltmc.chasm.lang.ast.StringExpression;
 
 public class ChasmStringNodeExpression extends StringExpression implements ChasmNodeExpression {
-    private final ValueNode<String> node;
+    private final ValueNode node;
 
-    public ChasmStringNodeExpression(ValueNode<String> node) {
-        super(node.getValue());
+    public ChasmStringNodeExpression(ValueNode node) {
+        super(node.getValueAsString());
         this.node = node;
     }
 
     @Override
-    public ValueNode<String> getNode() {
+    public ValueNode getNode() {
         return node;
     }
 }

--- a/chasm-lang/src/main/java/org/quiltmc/chasm/lang/interop/ConversionHelper.java
+++ b/chasm-lang/src/main/java/org/quiltmc/chasm/lang/interop/ConversionHelper.java
@@ -36,7 +36,7 @@ public abstract class ConversionHelper {
         }
 
         if (expression instanceof LiteralExpression<?>) {
-            return new ValueNode<>(((LiteralExpression<?>) expression).getValue());
+            return new ValueNode(((LiteralExpression<?>) expression).getValue());
         }
 
         throw new RuntimeException("Can't convert Expression to Node.");
@@ -49,19 +49,16 @@ public abstract class ConversionHelper {
         if (node instanceof ListNode) {
             return new ChasmListNodeExpression((ListNode) node);
         }
-        if (node instanceof ValueNode<?>) {
-            Object value = ((ValueNode<?>) node).getValue();
+        if (node instanceof ValueNode) {
+            Object value = ((ValueNode) node).getValue();
             if (value instanceof String) {
-                //noinspection unchecked
-                return new ChasmStringNodeExpression((ValueNode<String>) node);
+                return new ChasmStringNodeExpression((ValueNode) node);
             }
             if (value instanceof Integer) {
-                //noinspection unchecked
-                return new ChasmIntegerNodeExpression((ValueNode<Integer>) node);
+                return new ChasmIntegerNodeExpression((ValueNode) node);
             }
             if (value instanceof BooleanExpression) {
-                //noinspection unchecked
-                return new ChasmBooleanNodeExpression((ValueNode<Boolean>) node);
+                return new ChasmBooleanNodeExpression((ValueNode) node);
             }
         }
 

--- a/chasm-lang/src/main/java/org/quiltmc/chasm/lang/interop/ConversionHelper.java
+++ b/chasm-lang/src/main/java/org/quiltmc/chasm/lang/interop/ConversionHelper.java
@@ -44,21 +44,21 @@ public abstract class ConversionHelper {
 
     public static Expression convert(Node node) {
         if (node instanceof MapNode) {
-            return new ChasmMapNodeExpression((MapNode) node);
+            return new ChasmMapNodeExpression(Node.asMap(node));
         }
         if (node instanceof ListNode) {
-            return new ChasmListNodeExpression((ListNode) node);
+            return new ChasmListNodeExpression(Node.asList(node));
         }
         if (node instanceof ValueNode) {
-            Object value = ((ValueNode) node).getValue();
+            Object value = Node.asValue(node).getValue();
             if (value instanceof String) {
-                return new ChasmStringNodeExpression((ValueNode) node);
+                return new ChasmStringNodeExpression(Node.asValue(node));
             }
             if (value instanceof Integer) {
-                return new ChasmIntegerNodeExpression((ValueNode) node);
+                return new ChasmIntegerNodeExpression(Node.asValue(node));
             }
             if (value instanceof BooleanExpression) {
-                return new ChasmBooleanNodeExpression((ValueNode) node);
+                return new ChasmBooleanNodeExpression(Node.asValue(node));
             }
         }
 

--- a/chasm/src/main/java/org/quiltmc/chasm/api/ChasmProcessor.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/api/ChasmProcessor.java
@@ -70,7 +70,7 @@ public class ChasmProcessor {
         LOGGER.info("Writing {} classes...", classes.size());
         List<byte[]> classBytes = new ArrayList<>();
         for (Node node : classes) {
-            MapNode classNode = (MapNode) node;
+            MapNode classNode = Node.asMap(node);
 
             ClassNodeReader chasmWriter = new ClassNodeReader(classNode);
             ClassWriter classWriter = new ChasmClassWriter(new ChasmSuperClassProvider(superClassProvider, classes));

--- a/chasm/src/main/java/org/quiltmc/chasm/api/tree/Node.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/api/tree/Node.java
@@ -2,6 +2,7 @@ package org.quiltmc.chasm.api.tree;
 
 import org.jetbrains.annotations.ApiStatus;
 import org.quiltmc.chasm.internal.metadata.MetadataProvider;
+import org.quiltmc.chasm.internal.util.NodeUtils;
 
 public interface Node {
     /**
@@ -20,4 +21,34 @@ public interface Node {
      */
     @ApiStatus.Internal
     MetadataProvider getMetadata();
+
+    static MapNode asMap(Node node) {
+        if (node == null) {
+            return null;
+        }
+        if (node instanceof MapNode) {
+            return (MapNode) node;
+        }
+        throw NodeUtils.createWrongTypeException(node, "MapNode");
+    }
+
+    static ListNode asList(Node node) {
+        if (node == null) {
+            return null;
+        }
+        if (node instanceof ListNode) {
+            return (ListNode) node;
+        }
+        throw NodeUtils.createWrongTypeException(node, "ListNode");
+    }
+
+    static ValueNode asValue(Node node) {
+        if (node == null) {
+            return null;
+        }
+        if (node instanceof ValueNode) {
+            return (ValueNode) node;
+        }
+        throw NodeUtils.createWrongTypeException(node, "ValueNode");
+    }
 }

--- a/chasm/src/main/java/org/quiltmc/chasm/api/tree/ValueNode.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/api/tree/ValueNode.java
@@ -2,21 +2,51 @@ package org.quiltmc.chasm.api.tree;
 
 import org.quiltmc.chasm.internal.metadata.MetadataProvider;
 
-public class ValueNode<T> implements Node {
-    private final T value;
+public class ValueNode implements Node {
+    private final Object value;
     private MetadataProvider metadataProvider = new MetadataProvider();
 
-    public ValueNode(T value) {
+    public ValueNode(Object value) {
         this.value = value;
     }
 
-    public T getValue() {
+    public Object getValue() {
         return value;
     }
 
+    public <T> T getValueAs(Class<T> type) {
+        if (value == null) {
+            return null;
+        }
+        if (!type.isInstance(value)) {
+            throw new IllegalStateException("Value is not of expected type " + type + ", but is " + value.getClass() + "!");
+        }
+        return type.cast(value);
+    }
+
+    public String getValueAsString() {
+        return getValueAs(String.class);
+    }
+
+    public int getValueAsInt() {
+        Integer boxed = getValueAs(Integer.class);
+        if (boxed == null) {
+            throw new IllegalStateException("Value is null, but primitives can't be null!");
+        }
+        return boxed;
+    }
+
+    public boolean getValueAsBoolean() {
+        Boolean boxed = getValueAs(Boolean.class);
+        if (boxed == null) {
+            throw new IllegalStateException("Value is null, but primitives can't be null!");
+        }
+        return boxed;
+    }
+
     @Override
-    public ValueNode<T> copy() {
-        ValueNode<T> copy = new ValueNode<>(value);
+    public ValueNode copy() {
+        ValueNode copy = new ValueNode(value);
         copy.metadataProvider = metadataProvider.copy();
         return copy;
     }

--- a/chasm/src/main/java/org/quiltmc/chasm/api/tree/ValueNode.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/api/tree/ValueNode.java
@@ -19,7 +19,8 @@ public class ValueNode implements Node {
             return null;
         }
         if (!type.isInstance(value)) {
-            throw new IllegalStateException("Value is not of expected type " + type + ", but is " + value.getClass() + "!");
+            throw new IllegalStateException("Value is not of expected type " + type
+                    + ", but is " + value.getClass() + "!");
         }
         return type.cast(value);
     }

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/ChasmSuperClassProvider.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/ChasmSuperClassProvider.java
@@ -20,9 +20,9 @@ public class ChasmSuperClassProvider implements SuperClassProvider {
         this.parent = parent;
 
         for (Node node : classes) {
-            MapNode classNode = (MapNode) node;
-            ValueNode className = (ValueNode) classNode.get(NodeConstants.NAME);
-            ValueNode superName = (ValueNode) classNode.get(NodeConstants.SUPER);
+            MapNode classNode = Node.asMap(node);
+            ValueNode className = Node.asValue(classNode.get(NodeConstants.NAME));
+            ValueNode superName = Node.asValue(classNode.get(NodeConstants.SUPER));
             classNameToSuperClass.put(className.getValueAsString(),
                     superName == null ? OBJECT : superName.getValueAsString());
         }

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/ChasmSuperClassProvider.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/ChasmSuperClassProvider.java
@@ -16,15 +16,14 @@ public class ChasmSuperClassProvider implements SuperClassProvider {
     private final SuperClassProvider parent;
     private final Map<String, String> classNameToSuperClass = new HashMap<>();
 
-    @SuppressWarnings("unchecked")
     public ChasmSuperClassProvider(SuperClassProvider parent, ListNode classes) {
         this.parent = parent;
 
         for (Node node : classes) {
             MapNode classNode = (MapNode) node;
-            ValueNode<String> className = (ValueNode<String>) classNode.get(NodeConstants.NAME);
-            ValueNode<String> superName = (ValueNode<String>) classNode.get(NodeConstants.SUPER);
-            classNameToSuperClass.put(className.getValue(), superName == null ? OBJECT : superName.getValue());
+            ValueNode className = (ValueNode) classNode.get(NodeConstants.NAME);
+            ValueNode superName = (ValueNode) classNode.get(NodeConstants.SUPER);
+            classNameToSuperClass.put(className.getValueAsString(), superName == null ? OBJECT : superName.getValueAsString());
         }
     }
 

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/ChasmSuperClassProvider.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/ChasmSuperClassProvider.java
@@ -23,7 +23,8 @@ public class ChasmSuperClassProvider implements SuperClassProvider {
             MapNode classNode = (MapNode) node;
             ValueNode className = (ValueNode) classNode.get(NodeConstants.NAME);
             ValueNode superName = (ValueNode) classNode.get(NodeConstants.SUPER);
-            classNameToSuperClass.put(className.getValueAsString(), superName == null ? OBJECT : superName.getValueAsString());
+            classNameToSuperClass.put(className.getValueAsString(),
+                    superName == null ? OBJECT : superName.getValueAsString());
         }
     }
 

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/LazyClassNode.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/LazyClassNode.java
@@ -28,13 +28,13 @@ public class LazyClassNode extends AbstractMap<String, Node> implements MapNode 
 
         // NOTE: Ensure parity with names in ChasmClassVisitor
         this.nonLazyChildren = new LinkedHashMapNode();
-        this.nonLazyChildren.put(NodeConstants.ACCESS, new ValueNode<>(reader.getAccess()));
-        this.nonLazyChildren.put(NodeConstants.NAME, new ValueNode<>(reader.getClassName()));
-        this.nonLazyChildren.put(NodeConstants.SUPER, new ValueNode<>(reader.getSuperName()));
+        this.nonLazyChildren.put(NodeConstants.ACCESS, new ValueNode(reader.getAccess()));
+        this.nonLazyChildren.put(NodeConstants.NAME, new ValueNode(reader.getClassName()));
+        this.nonLazyChildren.put(NodeConstants.SUPER, new ValueNode(reader.getSuperName()));
 
         ListNode interfaces = new ArrayListNode();
         for (String iface : reader.getInterfaces()) {
-            interfaces.add(new ValueNode<>(iface));
+            interfaces.add(new ValueNode(iface));
         }
         this.nonLazyChildren.put(NodeConstants.INTERFACES, interfaces);
     }

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/TransformationApplier.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/TransformationApplier.java
@@ -79,7 +79,7 @@ public class TransformationApplier {
         if (target instanceof NodeTarget) {
             replaceNode((NodeTarget) target, replacement);
         } else if (target instanceof SliceTarget && replacement instanceof ListNode) {
-            replaceSlice((SliceTarget) target, (ListNode) replacement);
+            replaceSlice((SliceTarget) target, Node.asList(replacement));
         } else {
             throw new RuntimeException("Invalid replacement for target");
         }
@@ -98,13 +98,13 @@ public class TransformationApplier {
         PathMetadata.Entry entry = targetPath.get(targetPath.size() - 1);
 
         if (parentNode instanceof ListNode && entry.isInteger()) {
-            ListNode parentList = (ListNode) parentNode;
+            ListNode parentList = Node.asList(parentNode);
             parentList.set(entry.asInteger(), replacement);
             return;
         }
 
         if (parentNode instanceof MapNode && entry.isString()) {
-            MapNode parentList = (MapNode) parentNode;
+            MapNode parentList = Node.asMap(parentNode);
             parentList.put(entry.asString(), replacement);
             return;
         }
@@ -126,7 +126,7 @@ public class TransformationApplier {
             throw new UnsupportedOperationException("Replacement for slice target must be a list node.");
         }
 
-        ListNode parentList = (ListNode) parentNode;
+        ListNode parentList = Node.asList(parentNode);
 
         int change = parentList.size() - replacement.size();
         int start = sliceTarget.getStartIndex() / 2;
@@ -184,9 +184,9 @@ public class TransformationApplier {
 
         for (PathMetadata.Entry entry : path) {
             if (currentNode instanceof ListNode && entry.isInteger()) {
-                currentNode = ((ListNode) currentNode).get(entry.asInteger());
+                currentNode = Node.asList(currentNode).get(entry.asInteger());
             } else if (currentNode instanceof MapNode && entry.isString()) {
-                currentNode = ((MapNode) currentNode).get(entry.asString());
+                currentNode = Node.asMap(currentNode).get(entry.asString());
             } else {
                 throw new RuntimeException("Can't resolve path " + path);
             }

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/asm/visitor/ChasmAnnotationVisitor.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/asm/visitor/ChasmAnnotationVisitor.java
@@ -26,11 +26,11 @@ public class ChasmAnnotationVisitor extends AnnotationVisitor {
             }
             visitor.visitEnd();
         } else if (name == null) {
-            this.values.add(new ValueNode<>(value));
+            this.values.add(new ValueNode(value));
         } else {
             MapNode valueNode = new LinkedHashMapNode();
-            valueNode.put(NodeConstants.NAME, new ValueNode<>(name));
-            valueNode.put(NodeConstants.VALUE, new ValueNode<>(value));
+            valueNode.put(NodeConstants.NAME, new ValueNode(name));
+            valueNode.put(NodeConstants.VALUE, new ValueNode(value));
             this.values.add(valueNode);
         }
     }
@@ -38,12 +38,12 @@ public class ChasmAnnotationVisitor extends AnnotationVisitor {
     @Override
     public void visitEnum(String name, String descriptor, String value) {
         MapNode enumValueNode = new LinkedHashMapNode();
-        enumValueNode.put(NodeConstants.DESCRIPTOR, new ValueNode<>(descriptor));
-        enumValueNode.put(NodeConstants.VALUE, new ValueNode<>(value));
+        enumValueNode.put(NodeConstants.DESCRIPTOR, new ValueNode(descriptor));
+        enumValueNode.put(NodeConstants.VALUE, new ValueNode(value));
 
         if (name != null) {
             MapNode valueNode = new LinkedHashMapNode();
-            valueNode.put(NodeConstants.NAME, new ValueNode<>(name));
+            valueNode.put(NodeConstants.NAME, new ValueNode(name));
             valueNode.put(NodeConstants.VALUE, enumValueNode);
             this.values.add(valueNode);
         } else {
@@ -55,12 +55,12 @@ public class ChasmAnnotationVisitor extends AnnotationVisitor {
     public AnnotationVisitor visitAnnotation(String name, String descriptor) {
         MapNode annotationValueNode = new LinkedHashMapNode();
         ListNode values = new ArrayListNode();
-        annotationValueNode.put(NodeConstants.DESCRIPTOR, new ValueNode<>(descriptor));
+        annotationValueNode.put(NodeConstants.DESCRIPTOR, new ValueNode(descriptor));
         annotationValueNode.put(NodeConstants.VALUES, values);
 
         if (name != null) {
             MapNode valueNode = new LinkedHashMapNode();
-            valueNode.put(NodeConstants.NAME, new ValueNode<>(name));
+            valueNode.put(NodeConstants.NAME, new ValueNode(name));
             valueNode.put(NodeConstants.VALUE, annotationValueNode);
             this.values.add(valueNode);
         } else {
@@ -76,7 +76,7 @@ public class ChasmAnnotationVisitor extends AnnotationVisitor {
 
         if (name != null) {
             MapNode valueNode = new LinkedHashMapNode();
-            valueNode.put(NodeConstants.NAME, new ValueNode<>(name));
+            valueNode.put(NodeConstants.NAME, new ValueNode(name));
             valueNode.put(NodeConstants.VALUE, values);
             this.values.add(valueNode);
         } else {

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/asm/visitor/ChasmClassVisitor.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/asm/visitor/ChasmClassVisitor.java
@@ -40,15 +40,15 @@ public class ChasmClassVisitor extends ClassVisitor {
     @Override
     public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
         // NOTE: Ensure parity with names in ClassNode
-        classNode.put(NodeConstants.VERSION, new ValueNode<>(version));
-        classNode.put(NodeConstants.ACCESS, new ValueNode<>(access));
-        classNode.put(NodeConstants.NAME, new ValueNode<>(name));
-        classNode.put(NodeConstants.SIGNATURE, new ValueNode<>(signature));
-        classNode.put(NodeConstants.SUPER, new ValueNode<>(superName));
+        classNode.put(NodeConstants.VERSION, new ValueNode(version));
+        classNode.put(NodeConstants.ACCESS, new ValueNode(access));
+        classNode.put(NodeConstants.NAME, new ValueNode(name));
+        classNode.put(NodeConstants.SIGNATURE, new ValueNode(signature));
+        classNode.put(NodeConstants.SUPER, new ValueNode(superName));
 
         ListNode interfacesNode = new ArrayListNode();
         for (String iface : interfaces) {
-            interfacesNode.add(new ValueNode<>(iface));
+            interfacesNode.add(new ValueNode(iface));
         }
         classNode.put(NodeConstants.INTERFACES, interfacesNode);
 
@@ -67,20 +67,20 @@ public class ChasmClassVisitor extends ClassVisitor {
     @Override
     public void visitSource(String source, String debug) {
         if (source != null) {
-            classNode.put(NodeConstants.SOURCE, new ValueNode<>(source));
+            classNode.put(NodeConstants.SOURCE, new ValueNode(source));
         }
 
         if (debug != null) {
-            classNode.put(NodeConstants.DEBUG, new ValueNode<>(debug));
+            classNode.put(NodeConstants.DEBUG, new ValueNode(debug));
         }
     }
 
     @Override
     public ModuleVisitor visitModule(String name, int access, String version) {
         MapNode moduleNode = new LinkedHashMapNode();
-        moduleNode.put(NodeConstants.NAME, new ValueNode<>(name));
-        moduleNode.put(NodeConstants.ACCESS, new ValueNode<>(access));
-        moduleNode.put(NodeConstants.VERSION, new ValueNode<>(version));
+        moduleNode.put(NodeConstants.NAME, new ValueNode(name));
+        moduleNode.put(NodeConstants.ACCESS, new ValueNode(access));
+        moduleNode.put(NodeConstants.VERSION, new ValueNode(version));
         classNode.put(NodeConstants.MODULE, moduleNode);
 
         return new ChasmModuleVisitor(api, moduleNode);
@@ -88,22 +88,22 @@ public class ChasmClassVisitor extends ClassVisitor {
 
     @Override
     public void visitNestHost(String nestHost) {
-        classNode.put(NodeConstants.NEST_HOST, new ValueNode<>(nestHost));
+        classNode.put(NodeConstants.NEST_HOST, new ValueNode(nestHost));
     }
 
     @Override
     public void visitOuterClass(String owner, String name, String descriptor) {
-        classNode.put(NodeConstants.OWNER_CLASS, new ValueNode<>(owner));
-        classNode.put(NodeConstants.OWNER_METHOD, new ValueNode<>(name));
-        classNode.put(NodeConstants.OWNER_DESCRIPTOR, new ValueNode<>(descriptor));
+        classNode.put(NodeConstants.OWNER_CLASS, new ValueNode(owner));
+        classNode.put(NodeConstants.OWNER_METHOD, new ValueNode(name));
+        classNode.put(NodeConstants.OWNER_DESCRIPTOR, new ValueNode(descriptor));
     }
 
     @Override
     public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
         MapNode annotation = new LinkedHashMapNode();
         ListNode values = new ArrayListNode();
-        annotation.put(NodeConstants.DESCRIPTOR, new ValueNode<>(descriptor));
-        annotation.put(NodeConstants.VISIBLE, new ValueNode<>(visible));
+        annotation.put(NodeConstants.DESCRIPTOR, new ValueNode(descriptor));
+        annotation.put(NodeConstants.VISIBLE, new ValueNode(visible));
         annotation.put(NodeConstants.VALUES, values);
         annotations.add(annotation);
 
@@ -114,10 +114,10 @@ public class ChasmClassVisitor extends ClassVisitor {
     public AnnotationVisitor visitTypeAnnotation(int typeRef, TypePath typePath, String descriptor, boolean visible) {
         MapNode annotation = new LinkedHashMapNode();
         ListNode values = new ArrayListNode();
-        annotation.put(NodeConstants.DESCRIPTOR, new ValueNode<>(descriptor));
-        annotation.put(NodeConstants.VISIBLE, new ValueNode<>(visible));
-        annotation.put(NodeConstants.TYPE_REF, new ValueNode<>(typeRef));
-        annotation.put(NodeConstants.TYPE_PATH, new ValueNode<>(typePath.toString()));
+        annotation.put(NodeConstants.DESCRIPTOR, new ValueNode(descriptor));
+        annotation.put(NodeConstants.VISIBLE, new ValueNode(visible));
+        annotation.put(NodeConstants.TYPE_REF, new ValueNode(typeRef));
+        annotation.put(NodeConstants.TYPE_PATH, new ValueNode(typePath.toString()));
         annotation.put(NodeConstants.VALUES, values);
         annotations.add(annotation);
 
@@ -126,35 +126,35 @@ public class ChasmClassVisitor extends ClassVisitor {
 
     @Override
     public void visitAttribute(Attribute attribute) {
-        attributes.add(new ValueNode<>(attribute));
+        attributes.add(new ValueNode(attribute));
     }
 
     @Override
     public void visitNestMember(String nestMember) {
-        nestMembers.add(new ValueNode<>(nestMember));
+        nestMembers.add(new ValueNode(nestMember));
     }
 
     @Override
     public void visitPermittedSubclass(String permittedSubclass) {
-        permittedSubclasses.add(new ValueNode<>(permittedSubclass));
+        permittedSubclasses.add(new ValueNode(permittedSubclass));
     }
 
     @Override
     public void visitInnerClass(String name, String outerName, String innerName, int access) {
         MapNode innerClass = new LinkedHashMapNode();
-        innerClass.put(NodeConstants.NAME, new ValueNode<>(name));
-        innerClass.put(NodeConstants.OUTER_NAME, new ValueNode<>(outerName));
-        innerClass.put(NodeConstants.INNER_NAME, new ValueNode<>(innerName));
-        innerClass.put(NodeConstants.ACCESS, new ValueNode<>(access));
+        innerClass.put(NodeConstants.NAME, new ValueNode(name));
+        innerClass.put(NodeConstants.OUTER_NAME, new ValueNode(outerName));
+        innerClass.put(NodeConstants.INNER_NAME, new ValueNode(innerName));
+        innerClass.put(NodeConstants.ACCESS, new ValueNode(access));
         innerClasses.add(innerClass);
     }
 
     @Override
     public RecordComponentVisitor visitRecordComponent(String name, String descriptor, String signature) {
         MapNode recordComponentNode = new LinkedHashMapNode();
-        recordComponentNode.put(NodeConstants.NAME, new ValueNode<>(name));
-        recordComponentNode.put(NodeConstants.DESCRIPTOR, new ValueNode<>(descriptor));
-        recordComponentNode.put(NodeConstants.SIGNATURE, new ValueNode<>(signature));
+        recordComponentNode.put(NodeConstants.NAME, new ValueNode(name));
+        recordComponentNode.put(NodeConstants.DESCRIPTOR, new ValueNode(descriptor));
+        recordComponentNode.put(NodeConstants.SIGNATURE, new ValueNode(signature));
         recordComponents.add(recordComponentNode);
 
         return new ChasmRecordComponentVisitor(api, recordComponentNode);
@@ -164,11 +164,11 @@ public class ChasmClassVisitor extends ClassVisitor {
     public FieldVisitor visitField(int access, String name, String descriptor, String signature, Object value) {
         MapNode fieldNode = new LinkedHashMapNode();
 
-        fieldNode.put(NodeConstants.ACCESS, new ValueNode<>(access));
-        fieldNode.put(NodeConstants.NAME, new ValueNode<>(name));
-        fieldNode.put(NodeConstants.DESCRIPTOR, new ValueNode<>(descriptor));
-        fieldNode.put(NodeConstants.SIGNATURE, new ValueNode<>(signature));
-        fieldNode.put(NodeConstants.VALUE, new ValueNode<>(value));
+        fieldNode.put(NodeConstants.ACCESS, new ValueNode(access));
+        fieldNode.put(NodeConstants.NAME, new ValueNode(name));
+        fieldNode.put(NodeConstants.DESCRIPTOR, new ValueNode(descriptor));
+        fieldNode.put(NodeConstants.SIGNATURE, new ValueNode(signature));
+        fieldNode.put(NodeConstants.VALUE, new ValueNode(value));
         fields.add(fieldNode);
 
         return new ChasmFieldVisitor(api, fieldNode);
@@ -179,15 +179,15 @@ public class ChasmClassVisitor extends ClassVisitor {
                                      String[] exceptions) {
         MapNode methodNode = new LinkedHashMapNode();
 
-        methodNode.put(NodeConstants.ACCESS, new ValueNode<>(access));
-        methodNode.put(NodeConstants.NAME, new ValueNode<>(name));
-        methodNode.put(NodeConstants.DESCRIPTOR, new ValueNode<>(descriptor));
-        methodNode.put(NodeConstants.SIGNATURE, new ValueNode<>(signature));
+        methodNode.put(NodeConstants.ACCESS, new ValueNode(access));
+        methodNode.put(NodeConstants.NAME, new ValueNode(name));
+        methodNode.put(NodeConstants.DESCRIPTOR, new ValueNode(descriptor));
+        methodNode.put(NodeConstants.SIGNATURE, new ValueNode(signature));
 
         ListNode exceptionsNode = new ArrayListNode();
         if (exceptions != null) {
             for (String exception : exceptions) {
-                exceptionsNode.add(new ValueNode<>(exception));
+                exceptionsNode.add(new ValueNode(exception));
             }
         }
         methodNode.put(NodeConstants.EXCEPTIONS, exceptionsNode);

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/asm/visitor/ChasmFieldVisitor.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/asm/visitor/ChasmFieldVisitor.java
@@ -27,8 +27,8 @@ public class ChasmFieldVisitor extends FieldVisitor {
     public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
         MapNode annotation = new LinkedHashMapNode();
         ListNode values = new ArrayListNode();
-        annotation.put(NodeConstants.DESCRIPTOR, new ValueNode<>(descriptor));
-        annotation.put(NodeConstants.VISIBLE, new ValueNode<>(visible));
+        annotation.put(NodeConstants.DESCRIPTOR, new ValueNode(descriptor));
+        annotation.put(NodeConstants.VISIBLE, new ValueNode(visible));
         annotation.put(NodeConstants.VALUES, values);
         annotations.add(annotation);
 
@@ -39,11 +39,11 @@ public class ChasmFieldVisitor extends FieldVisitor {
     public AnnotationVisitor visitTypeAnnotation(int typeRef, TypePath typePath, String descriptor, boolean visible) {
         MapNode annotation = new LinkedHashMapNode();
         ListNode values = new ArrayListNode();
-        annotation.put(NodeConstants.DESCRIPTOR, new ValueNode<>(descriptor));
-        annotation.put(NodeConstants.VISIBLE, new ValueNode<>(visible));
-        annotation.put(NodeConstants.VALUES, new ValueNode<>(values));
-        annotation.put(NodeConstants.TYPE_REF, new ValueNode<>(typeRef));
-        annotation.put(NodeConstants.TYPE_PATH, new ValueNode<>(typePath.toString()));
+        annotation.put(NodeConstants.DESCRIPTOR, new ValueNode(descriptor));
+        annotation.put(NodeConstants.VISIBLE, new ValueNode(visible));
+        annotation.put(NodeConstants.VALUES, new ValueNode(values));
+        annotation.put(NodeConstants.TYPE_REF, new ValueNode(typeRef));
+        annotation.put(NodeConstants.TYPE_PATH, new ValueNode(typePath.toString()));
         annotations.add(annotation);
 
         return new ChasmAnnotationVisitor(api, values);
@@ -51,7 +51,7 @@ public class ChasmFieldVisitor extends FieldVisitor {
 
     @Override
     public void visitAttribute(Attribute attribute) {
-        attributes.add(new ValueNode<>(attribute));
+        attributes.add(new ValueNode(attribute));
     }
 
     @Override

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/asm/visitor/ChasmMethodVisitor.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/asm/visitor/ChasmMethodVisitor.java
@@ -45,8 +45,8 @@ public class ChasmMethodVisitor extends MethodVisitor {
     @Override
     public void visitParameter(String name, int access) {
         MapNode parameterNode = new LinkedHashMapNode();
-        parameterNode.put(NodeConstants.NAME, new ValueNode<>(name));
-        parameterNode.put(NodeConstants.ACCESS, new ValueNode<>(access));
+        parameterNode.put(NodeConstants.NAME, new ValueNode(name));
+        parameterNode.put(NodeConstants.ACCESS, new ValueNode(access));
         parameters.add(parameterNode);
     }
 
@@ -59,9 +59,9 @@ public class ChasmMethodVisitor extends MethodVisitor {
     public AnnotationVisitor visitParameterAnnotation(int parameter, String descriptor, boolean visible) {
         MapNode annotation = new LinkedHashMapNode();
         ListNode values = new ArrayListNode();
-        annotation.put(NodeConstants.PARAMETER, new ValueNode<>(parameter));
-        annotation.put(NodeConstants.DESCRIPTOR, new ValueNode<>(descriptor));
-        annotation.put(NodeConstants.VISIBLE, new ValueNode<>(visible));
+        annotation.put(NodeConstants.PARAMETER, new ValueNode(parameter));
+        annotation.put(NodeConstants.DESCRIPTOR, new ValueNode(descriptor));
+        annotation.put(NodeConstants.VISIBLE, new ValueNode(visible));
         annotation.put(NodeConstants.VALUES, values);
         parameterAnnotations.add(annotation);
 
@@ -82,8 +82,8 @@ public class ChasmMethodVisitor extends MethodVisitor {
     public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
         MapNode annotation = new LinkedHashMapNode();
         ListNode values = new ArrayListNode();
-        annotation.put(NodeConstants.DESCRIPTOR, new ValueNode<>(descriptor));
-        annotation.put(NodeConstants.VISIBLE, new ValueNode<>(visible));
+        annotation.put(NodeConstants.DESCRIPTOR, new ValueNode(descriptor));
+        annotation.put(NodeConstants.VISIBLE, new ValueNode(visible));
         annotation.put(NodeConstants.VALUES, values);
         annotations.add(annotation);
 
@@ -94,11 +94,11 @@ public class ChasmMethodVisitor extends MethodVisitor {
     public AnnotationVisitor visitTypeAnnotation(int typeRef, TypePath typePath, String descriptor, boolean visible) {
         MapNode annotation = new LinkedHashMapNode();
         ListNode values = new ArrayListNode();
-        annotation.put(NodeConstants.TYPE_REF, new ValueNode<>(typeRef));
-        annotation.put(NodeConstants.TYPE_PATH, new ValueNode<>(typePath.toString()));
-        annotation.put(NodeConstants.DESCRIPTOR, new ValueNode<>(descriptor));
-        annotation.put(NodeConstants.VISIBLE, new ValueNode<>(visible));
-        annotation.put(NodeConstants.VALUES, new ValueNode<>(values));
+        annotation.put(NodeConstants.TYPE_REF, new ValueNode(typeRef));
+        annotation.put(NodeConstants.TYPE_PATH, new ValueNode(typePath.toString()));
+        annotation.put(NodeConstants.DESCRIPTOR, new ValueNode(descriptor));
+        annotation.put(NodeConstants.VISIBLE, new ValueNode(visible));
+        annotation.put(NodeConstants.VALUES, new ValueNode(values));
         annotations.add(annotation);
 
         return new ChasmAnnotationVisitor(api, values);
@@ -106,7 +106,7 @@ public class ChasmMethodVisitor extends MethodVisitor {
 
     @Override
     public void visitAttribute(Attribute attribute) {
-        attributes.add(new ValueNode<>(attribute));
+        attributes.add(new ValueNode(attribute));
     }
 
     @Override
@@ -121,7 +121,7 @@ public class ChasmMethodVisitor extends MethodVisitor {
     @Override
     public void visitLabel(Label label) {
         MapNode labelNode = new LinkedHashMapNode();
-        labelNode.put(NodeConstants.LABEL, new ValueNode<>(label.toString()));
+        labelNode.put(NodeConstants.LABEL, new ValueNode(label.toString()));
         instructions.add(labelNode);
     }
 
@@ -133,52 +133,52 @@ public class ChasmMethodVisitor extends MethodVisitor {
     @Override
     public void visitInsn(int opcode) {
         MapNode instructionNode = new LinkedHashMapNode();
-        instructionNode.put(NodeConstants.OPCODE, new ValueNode<>(opcode));
+        instructionNode.put(NodeConstants.OPCODE, new ValueNode(opcode));
         instructions.add(instructionNode);
     }
 
     @Override
     public void visitIntInsn(int opcode, int operand) {
         MapNode instructionNode = new LinkedHashMapNode();
-        instructionNode.put(NodeConstants.OPCODE, new ValueNode<>(opcode));
-        instructionNode.put(NodeConstants.OPERAND, new ValueNode<>(operand));
+        instructionNode.put(NodeConstants.OPCODE, new ValueNode(opcode));
+        instructionNode.put(NodeConstants.OPERAND, new ValueNode(operand));
         instructions.add(instructionNode);
     }
 
     @Override
     public void visitVarInsn(int opcode, int var) {
         MapNode instructionNode = new LinkedHashMapNode();
-        instructionNode.put(NodeConstants.OPCODE, new ValueNode<>(opcode));
-        instructionNode.put(NodeConstants.VAR, new ValueNode<>(var));
+        instructionNode.put(NodeConstants.OPCODE, new ValueNode(opcode));
+        instructionNode.put(NodeConstants.VAR, new ValueNode(var));
         instructions.add(instructionNode);
     }
 
     @Override
     public void visitTypeInsn(int opcode, String type) {
         MapNode instructionNode = new LinkedHashMapNode();
-        instructionNode.put(NodeConstants.OPCODE, new ValueNode<>(opcode));
-        instructionNode.put(NodeConstants.TYPE, new ValueNode<>(type));
+        instructionNode.put(NodeConstants.OPCODE, new ValueNode(opcode));
+        instructionNode.put(NodeConstants.TYPE, new ValueNode(type));
         instructions.add(instructionNode);
     }
 
     @Override
     public void visitFieldInsn(int opcode, String owner, String name, String descriptor) {
         MapNode instructionNode = new LinkedHashMapNode();
-        instructionNode.put(NodeConstants.OPCODE, new ValueNode<>(opcode));
-        instructionNode.put(NodeConstants.OWNER, new ValueNode<>(owner));
-        instructionNode.put(NodeConstants.NAME, new ValueNode<>(name));
-        instructionNode.put(NodeConstants.DESCRIPTOR, new ValueNode<>(descriptor));
+        instructionNode.put(NodeConstants.OPCODE, new ValueNode(opcode));
+        instructionNode.put(NodeConstants.OWNER, new ValueNode(owner));
+        instructionNode.put(NodeConstants.NAME, new ValueNode(name));
+        instructionNode.put(NodeConstants.DESCRIPTOR, new ValueNode(descriptor));
         instructions.add(instructionNode);
     }
 
     @Override
     public void visitMethodInsn(int opcode, String owner, String name, String descriptor, boolean isInterface) {
         MapNode instructionNode = new LinkedHashMapNode();
-        instructionNode.put(NodeConstants.OPCODE, new ValueNode<>(opcode));
-        instructionNode.put(NodeConstants.OWNER, new ValueNode<>(owner));
-        instructionNode.put(NodeConstants.NAME, new ValueNode<>(name));
-        instructionNode.put(NodeConstants.DESCRIPTOR, new ValueNode<>(descriptor));
-        instructionNode.put(NodeConstants.IS_INTERFACE, new ValueNode<>(isInterface));
+        instructionNode.put(NodeConstants.OPCODE, new ValueNode(opcode));
+        instructionNode.put(NodeConstants.OWNER, new ValueNode(owner));
+        instructionNode.put(NodeConstants.NAME, new ValueNode(name));
+        instructionNode.put(NodeConstants.DESCRIPTOR, new ValueNode(descriptor));
+        instructionNode.put(NodeConstants.IS_INTERFACE, new ValueNode(isInterface));
         instructions.add(instructionNode);
     }
 
@@ -186,9 +186,9 @@ public class ChasmMethodVisitor extends MethodVisitor {
     public void visitInvokeDynamicInsn(String name, String descriptor, Handle bootstrapMethodHandle,
                                        Object... bootstrapMethodArguments) {
         MapNode instructionNode = new LinkedHashMapNode();
-        instructionNode.put(NodeConstants.OPCODE, new ValueNode<>(Opcodes.INVOKEDYNAMIC));
-        instructionNode.put(NodeConstants.NAME, new ValueNode<>(name));
-        instructionNode.put(NodeConstants.DESCRIPTOR, new ValueNode<>(descriptor));
+        instructionNode.put(NodeConstants.OPCODE, new ValueNode(Opcodes.INVOKEDYNAMIC));
+        instructionNode.put(NodeConstants.NAME, new ValueNode(name));
+        instructionNode.put(NodeConstants.DESCRIPTOR, new ValueNode(descriptor));
         instructionNode.put(NodeConstants.HANDLE, getHandleNode(bootstrapMethodHandle));
         instructionNode.put(NodeConstants.ARGUMENTS, getArgumentsNode(bootstrapMethodArguments));
         instructions.add(instructionNode);
@@ -196,11 +196,11 @@ public class ChasmMethodVisitor extends MethodVisitor {
 
     private MapNode getHandleNode(Handle handle) {
         MapNode handleNode = new LinkedHashMapNode();
-        handleNode.put(NodeConstants.TAG, new ValueNode<>(handle.getTag()));
-        handleNode.put(NodeConstants.OWNER, new ValueNode<>(handle.getOwner()));
-        handleNode.put(NodeConstants.NAME, new ValueNode<>(handle.getName()));
-        handleNode.put(NodeConstants.DESCRIPTOR, new ValueNode<>(handle.getDesc()));
-        handleNode.put(NodeConstants.IS_INTERFACE, new ValueNode<>(handle.isInterface()));
+        handleNode.put(NodeConstants.TAG, new ValueNode(handle.getTag()));
+        handleNode.put(NodeConstants.OWNER, new ValueNode(handle.getOwner()));
+        handleNode.put(NodeConstants.NAME, new ValueNode(handle.getName()));
+        handleNode.put(NodeConstants.DESCRIPTOR, new ValueNode(handle.getDesc()));
+        handleNode.put(NodeConstants.IS_INTERFACE, new ValueNode(handle.isInterface()));
         return handleNode;
     }
 
@@ -212,8 +212,8 @@ public class ChasmMethodVisitor extends MethodVisitor {
             } else if (arg instanceof ConstantDynamic) {
                 ConstantDynamic constantDynamic = (ConstantDynamic) arg;
                 MapNode constDynamicNode = new LinkedHashMapNode();
-                constDynamicNode.put(NodeConstants.NAME, new ValueNode<>(constantDynamic.getName()));
-                constDynamicNode.put(NodeConstants.DESCRIPTOR, new ValueNode<>(constantDynamic.getDescriptor()));
+                constDynamicNode.put(NodeConstants.NAME, new ValueNode(constantDynamic.getName()));
+                constDynamicNode.put(NodeConstants.DESCRIPTOR, new ValueNode(constantDynamic.getDescriptor()));
                 constDynamicNode.put(NodeConstants.HANDLE, getHandleNode(constantDynamic.getBootstrapMethod()));
                 Object[] arguments = new Object[constantDynamic.getBootstrapMethodArgumentCount()];
                 for (int i = 0; i < arguments.length; i++) {
@@ -222,7 +222,7 @@ public class ChasmMethodVisitor extends MethodVisitor {
                 constDynamicNode.put(NodeConstants.ARGUMENTS, getArgumentsNode(arguments));
                 argumentsNode.add(constDynamicNode);
             } else {
-                argumentsNode.add(new ValueNode<>(arg));
+                argumentsNode.add(new ValueNode(arg));
             }
         }
         return argumentsNode;
@@ -231,38 +231,38 @@ public class ChasmMethodVisitor extends MethodVisitor {
     @Override
     public void visitJumpInsn(int opcode, Label label) {
         MapNode instructionNode = new LinkedHashMapNode();
-        instructionNode.put(NodeConstants.OPCODE, new ValueNode<>(opcode));
-        instructionNode.put(NodeConstants.TARGET, new ValueNode<>(label.toString()));
+        instructionNode.put(NodeConstants.OPCODE, new ValueNode(opcode));
+        instructionNode.put(NodeConstants.TARGET, new ValueNode(label.toString()));
         instructions.add(instructionNode);
     }
 
     @Override
     public void visitLdcInsn(Object value) {
         MapNode instructionNode = new LinkedHashMapNode();
-        instructionNode.put(NodeConstants.OPCODE, new ValueNode<>(Opcodes.LDC));
-        instructionNode.put(NodeConstants.VALUE, new ValueNode<>(value));
+        instructionNode.put(NodeConstants.OPCODE, new ValueNode(Opcodes.LDC));
+        instructionNode.put(NodeConstants.VALUE, new ValueNode(value));
         instructions.add(instructionNode);
     }
 
     @Override
     public void visitIincInsn(int var, int increment) {
         MapNode instructionNode = new LinkedHashMapNode();
-        instructionNode.put(NodeConstants.OPCODE, new ValueNode<>(Opcodes.IINC));
-        instructionNode.put(NodeConstants.VAR, new ValueNode<>(var));
-        instructionNode.put(NodeConstants.INCREMENT, new ValueNode<>(increment));
+        instructionNode.put(NodeConstants.OPCODE, new ValueNode(Opcodes.IINC));
+        instructionNode.put(NodeConstants.VAR, new ValueNode(var));
+        instructionNode.put(NodeConstants.INCREMENT, new ValueNode(increment));
         instructions.add(instructionNode);
     }
 
     @Override
     public void visitTableSwitchInsn(int min, int max, Label dflt, Label... labels) {
         MapNode instructionNode = new LinkedHashMapNode();
-        instructionNode.put(NodeConstants.OPCODE, new ValueNode<>(Opcodes.TABLESWITCH));
-        instructionNode.put(NodeConstants.DEFAULT, new ValueNode<>(dflt.toString()));
+        instructionNode.put(NodeConstants.OPCODE, new ValueNode(Opcodes.TABLESWITCH));
+        instructionNode.put(NodeConstants.DEFAULT, new ValueNode(dflt.toString()));
         ListNode cases = new ArrayListNode();
         for (int i = 0; i < labels.length; i++) {
             MapNode caseNode = new LinkedHashMapNode();
-            caseNode.put(NodeConstants.KEY, new ValueNode<>(min + i));
-            caseNode.put(NodeConstants.LABEL, new ValueNode<>(labels[i].toString()));
+            caseNode.put(NodeConstants.KEY, new ValueNode(min + i));
+            caseNode.put(NodeConstants.LABEL, new ValueNode(labels[i].toString()));
             cases.add(caseNode);
         }
         instructionNode.put(NodeConstants.CASES, cases);
@@ -272,13 +272,13 @@ public class ChasmMethodVisitor extends MethodVisitor {
     @Override
     public void visitLookupSwitchInsn(Label dflt, int[] keys, Label[] labels) {
         MapNode instructionNode = new LinkedHashMapNode();
-        instructionNode.put(NodeConstants.OPCODE, new ValueNode<>(Opcodes.LOOKUPSWITCH));
-        instructionNode.put(NodeConstants.DEFAULT, new ValueNode<>(dflt.toString()));
+        instructionNode.put(NodeConstants.OPCODE, new ValueNode(Opcodes.LOOKUPSWITCH));
+        instructionNode.put(NodeConstants.DEFAULT, new ValueNode(dflt.toString()));
         ListNode cases = new ArrayListNode();
         for (int i = 0; i < labels.length; i++) {
             MapNode caseNode = new LinkedHashMapNode();
-            caseNode.put(NodeConstants.KEY, new ValueNode<>(keys[i]));
-            caseNode.put(NodeConstants.LABEL, new ValueNode<>(labels[i].toString()));
+            caseNode.put(NodeConstants.KEY, new ValueNode(keys[i]));
+            caseNode.put(NodeConstants.LABEL, new ValueNode(labels[i].toString()));
             cases.add(caseNode);
         }
         instructionNode.put(NodeConstants.CASES, cases);
@@ -288,9 +288,9 @@ public class ChasmMethodVisitor extends MethodVisitor {
     @Override
     public void visitMultiANewArrayInsn(String descriptor, int numDimensions) {
         MapNode instructionNode = new LinkedHashMapNode();
-        instructionNode.put(NodeConstants.OPCODE, new ValueNode<>(Opcodes.MULTIANEWARRAY));
-        instructionNode.put(NodeConstants.DESCRIPTOR, new ValueNode<>(descriptor));
-        instructionNode.put(NodeConstants.DIMENSIONS, new ValueNode<>(numDimensions));
+        instructionNode.put(NodeConstants.OPCODE, new ValueNode(Opcodes.MULTIANEWARRAY));
+        instructionNode.put(NodeConstants.DESCRIPTOR, new ValueNode(descriptor));
+        instructionNode.put(NodeConstants.DIMENSIONS, new ValueNode(numDimensions));
         instructions.add(instructionNode);
     }
 
@@ -300,11 +300,11 @@ public class ChasmMethodVisitor extends MethodVisitor {
 
         MapNode annotation = new LinkedHashMapNode();
         ListNode values = new ArrayListNode();
-        annotation.put(NodeConstants.DESCRIPTOR, new ValueNode<>(descriptor));
-        annotation.put(NodeConstants.VISIBLE, new ValueNode<>(visible));
-        annotation.put(NodeConstants.VALUES, new ValueNode<>(values));
-        annotation.put(NodeConstants.TYPE_REF, new ValueNode<>(typeRef));
-        annotation.put(NodeConstants.TYPE_PATH, new ValueNode<>(typePath.toString()));
+        annotation.put(NodeConstants.DESCRIPTOR, new ValueNode(descriptor));
+        annotation.put(NodeConstants.VISIBLE, new ValueNode(visible));
+        annotation.put(NodeConstants.VALUES, new ValueNode(values));
+        annotation.put(NodeConstants.TYPE_REF, new ValueNode(typeRef));
+        annotation.put(NodeConstants.TYPE_PATH, new ValueNode(typePath.toString()));
 
         ListNode annotations = (ListNode) instructionNode
                 .computeIfAbsent(NodeConstants.ANNOTATIONS, s -> new ArrayListNode());
@@ -316,10 +316,10 @@ public class ChasmMethodVisitor extends MethodVisitor {
     @Override
     public void visitTryCatchBlock(Label start, Label end, Label handler, String type) {
         MapNode tryCatchBlock = new LinkedHashMapNode();
-        tryCatchBlock.put(NodeConstants.START, new ValueNode<>(start.toString()));
-        tryCatchBlock.put(NodeConstants.END, new ValueNode<>(end.toString()));
-        tryCatchBlock.put(NodeConstants.HANDLER, new ValueNode<>(handler.toString()));
-        tryCatchBlock.put(NodeConstants.TYPE, new ValueNode<>(type));
+        tryCatchBlock.put(NodeConstants.START, new ValueNode(start.toString()));
+        tryCatchBlock.put(NodeConstants.END, new ValueNode(end.toString()));
+        tryCatchBlock.put(NodeConstants.HANDLER, new ValueNode(handler.toString()));
+        tryCatchBlock.put(NodeConstants.TYPE, new ValueNode(type));
         tryCatchBlock.put(NodeConstants.ANNOTATIONS, new ArrayListNode());
         tryCatchBlocks.add(tryCatchBlock);
     }
@@ -331,11 +331,11 @@ public class ChasmMethodVisitor extends MethodVisitor {
 
         MapNode annotation = new LinkedHashMapNode();
         ListNode values = new ArrayListNode();
-        annotation.put(NodeConstants.DESCRIPTOR, new ValueNode<>(descriptor));
-        annotation.put(NodeConstants.VISIBLE, new ValueNode<>(visible));
-        annotation.put(NodeConstants.VALUES, new ValueNode<>(values));
-        annotation.put(NodeConstants.TYPE_REF, new ValueNode<>(typeRef));
-        annotation.put(NodeConstants.TYPE_PATH, new ValueNode<>(typePath.toString()));
+        annotation.put(NodeConstants.DESCRIPTOR, new ValueNode(descriptor));
+        annotation.put(NodeConstants.VISIBLE, new ValueNode(visible));
+        annotation.put(NodeConstants.VALUES, new ValueNode(values));
+        annotation.put(NodeConstants.TYPE_REF, new ValueNode(typeRef));
+        annotation.put(NodeConstants.TYPE_PATH, new ValueNode(typePath.toString()));
 
         ListNode annotations = (ListNode) tryCatchBlock.get(NodeConstants.ANNOTATIONS);
         annotations.add(annotation);
@@ -348,12 +348,12 @@ public class ChasmMethodVisitor extends MethodVisitor {
                                    int index) {
         // TODO: I think locals could be handled better than this
         MapNode localNode = new LinkedHashMapNode();
-        localNode.put(NodeConstants.NAME, new ValueNode<>(name));
-        localNode.put(NodeConstants.DESCRIPTOR, new ValueNode<>(descriptor));
-        localNode.put(NodeConstants.SIGNATURE, new ValueNode<>(signature));
-        localNode.put(NodeConstants.START, new ValueNode<>(start.toString()));
-        localNode.put(NodeConstants.END, new ValueNode<>(end.toString()));
-        localNode.put(NodeConstants.INDEX, new ValueNode<>(index));
+        localNode.put(NodeConstants.NAME, new ValueNode(name));
+        localNode.put(NodeConstants.DESCRIPTOR, new ValueNode(descriptor));
+        localNode.put(NodeConstants.SIGNATURE, new ValueNode(signature));
+        localNode.put(NodeConstants.START, new ValueNode(start.toString()));
+        localNode.put(NodeConstants.END, new ValueNode(end.toString()));
+        localNode.put(NodeConstants.INDEX, new ValueNode(index));
         locals.add(localNode);
     }
 
@@ -367,8 +367,8 @@ public class ChasmMethodVisitor extends MethodVisitor {
     @Override
     public void visitLineNumber(int line, Label start) {
         MapNode lineNode = new LinkedHashMapNode();
-        lineNode.put(NodeConstants.LINE, new ValueNode<>(line));
-        lineNode.put(NodeConstants.LABEL, new ValueNode<>(start.toString()));
+        lineNode.put(NodeConstants.LINE, new ValueNode(line));
+        lineNode.put(NodeConstants.LABEL, new ValueNode(start.toString()));
         lineNumbers.add(lineNode);
     }
 

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/asm/visitor/ChasmMethodVisitor.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/asm/visitor/ChasmMethodVisitor.java
@@ -12,6 +12,7 @@ import org.quiltmc.chasm.api.tree.ArrayListNode;
 import org.quiltmc.chasm.api.tree.LinkedHashMapNode;
 import org.quiltmc.chasm.api.tree.ListNode;
 import org.quiltmc.chasm.api.tree.MapNode;
+import org.quiltmc.chasm.api.tree.Node;
 import org.quiltmc.chasm.api.tree.ValueNode;
 import org.quiltmc.chasm.internal.util.NodeConstants;
 
@@ -296,7 +297,7 @@ public class ChasmMethodVisitor extends MethodVisitor {
 
     @Override
     public AnnotationVisitor visitInsnAnnotation(int typeRef, TypePath typePath, String descriptor, boolean visible) {
-        MapNode instructionNode = (MapNode) instructions.get(instructions.size() - 1);
+        MapNode instructionNode = Node.asMap(instructions.get(instructions.size() - 1));
 
         MapNode annotation = new LinkedHashMapNode();
         ListNode values = new ArrayListNode();
@@ -306,8 +307,8 @@ public class ChasmMethodVisitor extends MethodVisitor {
         annotation.put(NodeConstants.TYPE_REF, new ValueNode(typeRef));
         annotation.put(NodeConstants.TYPE_PATH, new ValueNode(typePath.toString()));
 
-        ListNode annotations = (ListNode) instructionNode
-                .computeIfAbsent(NodeConstants.ANNOTATIONS, s -> new ArrayListNode());
+        ListNode annotations = Node.asList(Node.asMap(instructionNode)
+                .computeIfAbsent(NodeConstants.ANNOTATIONS, s -> new ArrayListNode()));
         annotations.add(annotation);
 
         return new ChasmAnnotationVisitor(api, values);
@@ -327,7 +328,7 @@ public class ChasmMethodVisitor extends MethodVisitor {
     @Override
     public AnnotationVisitor visitTryCatchAnnotation(int typeRef, TypePath typePath, String descriptor,
                                                      boolean visible) {
-        MapNode tryCatchBlock = (MapNode) tryCatchBlocks.get(tryCatchBlocks.size() - 1);
+        MapNode tryCatchBlock = Node.asMap(tryCatchBlocks.get(tryCatchBlocks.size() - 1));
 
         MapNode annotation = new LinkedHashMapNode();
         ListNode values = new ArrayListNode();
@@ -337,7 +338,7 @@ public class ChasmMethodVisitor extends MethodVisitor {
         annotation.put(NodeConstants.TYPE_REF, new ValueNode(typeRef));
         annotation.put(NodeConstants.TYPE_PATH, new ValueNode(typePath.toString()));
 
-        ListNode annotations = (ListNode) tryCatchBlock.get(NodeConstants.ANNOTATIONS);
+        ListNode annotations = Node.asList(tryCatchBlock.get(NodeConstants.ANNOTATIONS));
         annotations.add(annotation);
 
         return new ChasmAnnotationVisitor(api, values);

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/asm/visitor/ChasmModuleVisitor.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/asm/visitor/ChasmModuleVisitor.java
@@ -32,32 +32,32 @@ public class ChasmModuleVisitor extends ModuleVisitor {
 
     @Override
     public void visitMainClass(String mainClass) {
-        moduleNode.put(NodeConstants.MAIN, new ValueNode<>(mainClass));
+        moduleNode.put(NodeConstants.MAIN, new ValueNode(mainClass));
     }
 
     @Override
     public void visitPackage(String packaze) {
-        packages.add(new ValueNode<>(packaze));
+        packages.add(new ValueNode(packaze));
     }
 
     @Override
     public void visitRequire(String module, int access, String version) {
         MapNode requireNode = new LinkedHashMapNode();
-        requireNode.put(NodeConstants.MODULE, new ValueNode<>(module));
-        requireNode.put(NodeConstants.ACCESS, new ValueNode<>(access));
-        requireNode.put(NodeConstants.VERSION, new ValueNode<>(version));
+        requireNode.put(NodeConstants.MODULE, new ValueNode(module));
+        requireNode.put(NodeConstants.ACCESS, new ValueNode(access));
+        requireNode.put(NodeConstants.VERSION, new ValueNode(version));
         requires.add(requireNode);
     }
 
     @Override
     public void visitExport(String packaze, int access, String... modules) {
         MapNode exportNode = new LinkedHashMapNode();
-        exportNode.put(NodeConstants.PACKAGE, new ValueNode<>(packaze));
-        exportNode.put(NodeConstants.ACCESS, new ValueNode<>(access));
+        exportNode.put(NodeConstants.PACKAGE, new ValueNode(packaze));
+        exportNode.put(NodeConstants.ACCESS, new ValueNode(access));
         if (modules != null) {
             ListNode modulesNode = new ArrayListNode();
             for (String m : modules) {
-                modulesNode.add(new ValueNode<>(m));
+                modulesNode.add(new ValueNode(m));
             }
             exportNode.put(NodeConstants.MODULES, modulesNode);
         }
@@ -67,12 +67,12 @@ public class ChasmModuleVisitor extends ModuleVisitor {
     @Override
     public void visitOpen(String packaze, int access, String... modules) {
         MapNode openNode = new LinkedHashMapNode();
-        openNode.put(NodeConstants.PACKAGE, new ValueNode<>(packaze));
-        openNode.put(NodeConstants.ACCESS, new ValueNode<>(access));
+        openNode.put(NodeConstants.PACKAGE, new ValueNode(packaze));
+        openNode.put(NodeConstants.ACCESS, new ValueNode(access));
         if (modules != null) {
             ListNode modulesNode = new ArrayListNode();
             for (String m : modules) {
-                modulesNode.add(new ValueNode<>(m));
+                modulesNode.add(new ValueNode(m));
             }
             openNode.put(NodeConstants.MODULES, modulesNode);
         }
@@ -81,16 +81,16 @@ public class ChasmModuleVisitor extends ModuleVisitor {
 
     @Override
     public void visitUse(String service) {
-        uses.add(new ValueNode<>(service));
+        uses.add(new ValueNode(service));
     }
 
     @Override
     public void visitProvide(String service, String... providers) {
         MapNode provideNode = new LinkedHashMapNode();
-        provideNode.put(NodeConstants.SERVICE, new ValueNode<>(service));
+        provideNode.put(NodeConstants.SERVICE, new ValueNode(service));
         ListNode providersNode = new ArrayListNode();
         for (String provider : providers) {
-            providersNode.add(new ValueNode<>(provider));
+            providersNode.add(new ValueNode(provider));
         }
         provideNode.put(NodeConstants.PROVIDERS, providersNode);
         provides.add(provideNode);

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/asm/visitor/ChasmRecordComponentVisitor.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/asm/visitor/ChasmRecordComponentVisitor.java
@@ -26,8 +26,8 @@ public class ChasmRecordComponentVisitor extends RecordComponentVisitor {
     public AnnotationVisitor visitAnnotation(String descriptor, boolean visible) {
         MapNode annotation = new LinkedHashMapNode();
         ListNode values = new ArrayListNode();
-        annotation.put(NodeConstants.DESCRIPTOR, new ValueNode<>(descriptor));
-        annotation.put(NodeConstants.VISIBLE, new ValueNode<>(visible));
+        annotation.put(NodeConstants.DESCRIPTOR, new ValueNode(descriptor));
+        annotation.put(NodeConstants.VISIBLE, new ValueNode(visible));
         annotation.put(NodeConstants.VALUES, values);
         annotations.add(annotation);
 
@@ -38,11 +38,11 @@ public class ChasmRecordComponentVisitor extends RecordComponentVisitor {
     public AnnotationVisitor visitTypeAnnotation(int typeRef, TypePath typePath, String descriptor, boolean visible) {
         MapNode annotation = new LinkedHashMapNode();
         ListNode values = new ArrayListNode();
-        annotation.put(NodeConstants.DESCRIPTOR, new ValueNode<>(descriptor));
-        annotation.put(NodeConstants.VISIBLE, new ValueNode<>(visible));
+        annotation.put(NodeConstants.DESCRIPTOR, new ValueNode(descriptor));
+        annotation.put(NodeConstants.VISIBLE, new ValueNode(visible));
         annotation.put(NodeConstants.VALUES, values);
-        annotation.put(NodeConstants.TYPE_REF, new ValueNode<>(typeRef));
-        annotation.put(NodeConstants.TYPE_PATH, new ValueNode<>(typePath.toString()));
+        annotation.put(NodeConstants.TYPE_REF, new ValueNode(typeRef));
+        annotation.put(NodeConstants.TYPE_PATH, new ValueNode(typePath.toString()));
         annotations.add(annotation);
 
         return new ChasmAnnotationVisitor(api, values);
@@ -50,7 +50,7 @@ public class ChasmRecordComponentVisitor extends RecordComponentVisitor {
 
     @Override
     public void visitAttribute(Attribute attribute) {
-        attributes.add(new ValueNode<>(attribute));
+        attributes.add(new ValueNode(attribute));
     }
 
     @Override

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/metadata/PathMetadata.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/metadata/PathMetadata.java
@@ -58,9 +58,9 @@ public class PathMetadata extends ArrayList<PathMetadata.Entry> implements Metad
         Node current = root;
         for (Entry entry : this) {
             if (entry.isInteger() && current instanceof ListNode) {
-                current = ((ListNode) current).get(entry.asInteger());
+                current = Node.asList(current).get(entry.asInteger());
             } else if (entry.isString() && current instanceof MapNode) {
-                current = ((MapNode) current).get(entry.asString());
+                current = Node.asMap(current).get(entry.asString());
             } else {
                 throw new UnsupportedOperationException("Can't apply path to given node.");
             }

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/tree/reader/AnnotationNodeReader.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/tree/reader/AnnotationNodeReader.java
@@ -19,9 +19,9 @@ public class AnnotationNodeReader {
     public void visitAnnotation(AnnotationVisitor visitor) {
         ListNode values;
         if (annotationNode instanceof MapNode) {
-            values = (ListNode) ((MapNode) annotationNode).get(NodeConstants.VALUES);
+            values = Node.asList(Node.asMap(annotationNode).get(NodeConstants.VALUES));
         } else {
-            values = (ListNode) annotationNode;
+            values = Node.asList(annotationNode);
         }
         if (values == null) {
             visitor.visitEnd();
@@ -30,29 +30,29 @@ public class AnnotationNodeReader {
 
         for (Node value : values) {
             String name = null;
-            if (value instanceof MapNode && ((MapNode) value).containsKey(NodeConstants.NAME)) {
-                MapNode mapNode = (MapNode) value;
+            if (value instanceof MapNode && (Node.asMap(value)).containsKey(NodeConstants.NAME)) {
+                MapNode mapNode = Node.asMap(value);
                 // Name-value pairs
-                name = ((ValueNode) mapNode.get(NodeConstants.NAME)).getValueAsString();
+                name = Node.asValue(mapNode.get(NodeConstants.NAME)).getValueAsString();
                 value = mapNode.get(NodeConstants.VALUE);
             }
 
             if (value instanceof ValueNode) {
-                visitor.visit(name, ((ValueNode) value).getValue());
+                visitor.visit(name, Node.asValue(value).getValue());
             } else if (value instanceof ListNode) {
                 AnnotationVisitor arrayVisitor = visitor.visitArray(name);
 
                 new AnnotationNodeReader(value).visitAnnotation(arrayVisitor);
             } else {
-                MapNode mapNode = (MapNode) value;
+                MapNode mapNode = Node.asMap(value);
                 if (mapNode.containsKey(NodeConstants.VALUE)) {
-                    String descriptor = ((ValueNode) mapNode.get(NodeConstants.DESCRIPTOR)).getValueAsString();
-                    String enumValue = ((ValueNode) mapNode.get(NodeConstants.VALUE)).getValueAsString();
+                    String descriptor = Node.asValue(mapNode.get(NodeConstants.DESCRIPTOR)).getValueAsString();
+                    String enumValue = Node.asValue(mapNode.get(NodeConstants.VALUE)).getValueAsString();
 
                     visitor.visitEnum(name, descriptor, enumValue);
                 } else {
-                    String descriptor = ((ValueNode) mapNode.get(NodeConstants.DESCRIPTOR)).getValueAsString();
-                    ListNode annotationValues = (ListNode) mapNode.get(NodeConstants.VALUES);
+                    String descriptor = Node.asValue(mapNode.get(NodeConstants.DESCRIPTOR)).getValueAsString();
+                    ListNode annotationValues = Node.asList(mapNode.get(NodeConstants.VALUES));
 
                     AnnotationVisitor annotationVisitor = visitor.visitAnnotation(name, descriptor);
                     new AnnotationNodeReader(annotationValues).visitAnnotation(annotationVisitor);
@@ -64,10 +64,10 @@ public class AnnotationNodeReader {
     }
 
     public void visitAnnotation(VisitAnnotation visitAnnotation, VisitTypeAnnotation visitTypeAnnotation) {
-        ValueNode annotationDesc = (ValueNode) ((MapNode) annotationNode).get(NodeConstants.DESCRIPTOR);
-        ValueNode visible = (ValueNode) ((MapNode) annotationNode).get(NodeConstants.VISIBLE);
-        ValueNode typeRef = (ValueNode) ((MapNode) annotationNode).get(NodeConstants.TYPE_REF);
-        ValueNode typePath = (ValueNode) ((MapNode) annotationNode).get(NodeConstants.TYPE_PATH);
+        ValueNode annotationDesc = Node.asValue(Node.asMap(annotationNode).get(NodeConstants.DESCRIPTOR));
+        ValueNode visible = Node.asValue(Node.asMap(annotationNode).get(NodeConstants.VISIBLE));
+        ValueNode typeRef = Node.asValue(Node.asMap(annotationNode).get(NodeConstants.TYPE_REF));
+        ValueNode typePath = Node.asValue(Node.asMap(annotationNode).get(NodeConstants.TYPE_PATH));
         AnnotationVisitor annotationVisitor;
         if (typeRef == null) {
             annotationVisitor = visitAnnotation.visitAnnotation(annotationDesc.getValueAsString(),

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/tree/reader/AnnotationNodeReader.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/tree/reader/AnnotationNodeReader.java
@@ -70,7 +70,8 @@ public class AnnotationNodeReader {
         ValueNode typePath = (ValueNode) ((MapNode) annotationNode).get(NodeConstants.TYPE_PATH);
         AnnotationVisitor annotationVisitor;
         if (typeRef == null) {
-            annotationVisitor = visitAnnotation.visitAnnotation(annotationDesc.getValueAsString(), visible.getValueAsBoolean());
+            annotationVisitor = visitAnnotation.visitAnnotation(annotationDesc.getValueAsString(),
+                    visible.getValueAsBoolean());
         } else {
             annotationVisitor = visitTypeAnnotation.visitTypeAnnotation(typeRef.getValueAsInt(),
                     TypePath.fromString(typePath.getValueAsString()), annotationDesc.getValueAsString(),

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/tree/reader/AnnotationNodeReader.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/tree/reader/AnnotationNodeReader.java
@@ -8,7 +8,6 @@ import org.quiltmc.chasm.api.tree.Node;
 import org.quiltmc.chasm.api.tree.ValueNode;
 import org.quiltmc.chasm.internal.util.NodeConstants;
 
-@SuppressWarnings("unchecked")
 public class AnnotationNodeReader {
     private final Node annotationNode;
 
@@ -34,12 +33,12 @@ public class AnnotationNodeReader {
             if (value instanceof MapNode && ((MapNode) value).containsKey(NodeConstants.NAME)) {
                 MapNode mapNode = (MapNode) value;
                 // Name-value pairs
-                name = ((ValueNode<String>) mapNode.get(NodeConstants.NAME)).getValue();
+                name = ((ValueNode) mapNode.get(NodeConstants.NAME)).getValueAsString();
                 value = mapNode.get(NodeConstants.VALUE);
             }
 
             if (value instanceof ValueNode) {
-                visitor.visit(name, ((ValueNode<Object>) value).getValue());
+                visitor.visit(name, ((ValueNode) value).getValue());
             } else if (value instanceof ListNode) {
                 AnnotationVisitor arrayVisitor = visitor.visitArray(name);
 
@@ -47,12 +46,12 @@ public class AnnotationNodeReader {
             } else {
                 MapNode mapNode = (MapNode) value;
                 if (mapNode.containsKey(NodeConstants.VALUE)) {
-                    String descriptor = ((ValueNode<String>) mapNode.get(NodeConstants.DESCRIPTOR)).getValue();
-                    String enumValue = ((ValueNode<String>) mapNode.get(NodeConstants.VALUE)).getValue();
+                    String descriptor = ((ValueNode) mapNode.get(NodeConstants.DESCRIPTOR)).getValueAsString();
+                    String enumValue = ((ValueNode) mapNode.get(NodeConstants.VALUE)).getValueAsString();
 
                     visitor.visitEnum(name, descriptor, enumValue);
                 } else {
-                    String descriptor = ((ValueNode<String>) mapNode.get(NodeConstants.DESCRIPTOR)).getValue();
+                    String descriptor = ((ValueNode) mapNode.get(NodeConstants.DESCRIPTOR)).getValueAsString();
                     ListNode annotationValues = (ListNode) mapNode.get(NodeConstants.VALUES);
 
                     AnnotationVisitor annotationVisitor = visitor.visitAnnotation(name, descriptor);
@@ -65,17 +64,17 @@ public class AnnotationNodeReader {
     }
 
     public void visitAnnotation(VisitAnnotation visitAnnotation, VisitTypeAnnotation visitTypeAnnotation) {
-        ValueNode<String> annotationDesc = (ValueNode<String>) ((MapNode) annotationNode).get(NodeConstants.DESCRIPTOR);
-        ValueNode<Boolean> visible = (ValueNode<Boolean>) ((MapNode) annotationNode).get(NodeConstants.VISIBLE);
-        ValueNode<Integer> typeRef = (ValueNode<Integer>) ((MapNode) annotationNode).get(NodeConstants.TYPE_REF);
-        ValueNode<String> typePath = (ValueNode<String>) ((MapNode) annotationNode).get(NodeConstants.TYPE_PATH);
+        ValueNode annotationDesc = (ValueNode) ((MapNode) annotationNode).get(NodeConstants.DESCRIPTOR);
+        ValueNode visible = (ValueNode) ((MapNode) annotationNode).get(NodeConstants.VISIBLE);
+        ValueNode typeRef = (ValueNode) ((MapNode) annotationNode).get(NodeConstants.TYPE_REF);
+        ValueNode typePath = (ValueNode) ((MapNode) annotationNode).get(NodeConstants.TYPE_PATH);
         AnnotationVisitor annotationVisitor;
         if (typeRef == null) {
-            annotationVisitor = visitAnnotation.visitAnnotation(annotationDesc.getValue(), visible.getValue());
+            annotationVisitor = visitAnnotation.visitAnnotation(annotationDesc.getValueAsString(), visible.getValueAsBoolean());
         } else {
-            annotationVisitor = visitTypeAnnotation.visitTypeAnnotation(typeRef.getValue(),
-                    TypePath.fromString(typePath.getValue()), annotationDesc.getValue(),
-                    visible.getValue());
+            annotationVisitor = visitTypeAnnotation.visitTypeAnnotation(typeRef.getValueAsInt(),
+                    TypePath.fromString(typePath.getValueAsString()), annotationDesc.getValueAsString(),
+                    visible.getValueAsBoolean());
         }
         visitAnnotation(annotationVisitor);
     }

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/tree/reader/ClassNodeReader.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/tree/reader/ClassNodeReader.java
@@ -9,7 +9,6 @@ import org.quiltmc.chasm.api.tree.ValueNode;
 import org.quiltmc.chasm.internal.LazyClassNode;
 import org.quiltmc.chasm.internal.util.NodeConstants;
 
-@SuppressWarnings("unchecked")
 public class ClassNodeReader {
     private final MapNode classNode;
 
@@ -25,20 +24,20 @@ public class ClassNodeReader {
         }
 
         // visit
-        int version = ((ValueNode<Integer>) classNode.get(NodeConstants.VERSION)).getValue();
-        int access = ((ValueNode<Integer>) classNode.get(NodeConstants.ACCESS)).getValue();
-        String name = ((ValueNode<String>) classNode.get(NodeConstants.NAME)).getValue();
+        int version = ((ValueNode) classNode.get(NodeConstants.VERSION)).getValueAsInt();
+        int access = ((ValueNode) classNode.get(NodeConstants.ACCESS)).getValueAsInt();
+        String name = ((ValueNode) classNode.get(NodeConstants.NAME)).getValueAsString();
 
-        ValueNode<String> signatureNode = (ValueNode<String>) classNode.get(NodeConstants.SIGNATURE);
-        String signature = signatureNode == null ? null : signatureNode.getValue();
+        ValueNode signatureNode = (ValueNode) classNode.get(NodeConstants.SIGNATURE);
+        String signature = signatureNode == null ? null : signatureNode.getValueAsString();
 
-        ValueNode<String> superClassNode = (ValueNode<String>) classNode.get(NodeConstants.SUPER);
-        String superClass = superClassNode == null ? "java/lang/Object" : superClassNode.getValue();
+        ValueNode superClassNode = (ValueNode) classNode.get(NodeConstants.SUPER);
+        String superClass = superClassNode == null ? "java/lang/Object" : superClassNode.getValueAsString();
 
         ListNode interfacesNode = (ListNode) classNode.get(NodeConstants.INTERFACES);
         String[] interfaces = interfacesNode == null ? new String[0]
                 :
-                interfacesNode.stream().map(n -> ((ValueNode<String>) n).getValue()).toArray(String[]::new);
+                interfacesNode.stream().map(n -> ((ValueNode) n).getValueAsString()).toArray(String[]::new);
 
         visitor.visit(version, access, name, signature, superClass, interfaces);
 
@@ -109,15 +108,15 @@ public class ClassNodeReader {
         }
         for (Node n : innerClassesListNode) {
             MapNode innerClass = (MapNode) n;
-            ValueNode<String> nameNode = (ValueNode<String>) innerClass.get(NodeConstants.NAME);
-            ValueNode<String> outerNameNode = (ValueNode<String>) innerClass.get(NodeConstants.OUTER_NAME);
-            ValueNode<String> innerNameNode = (ValueNode<String>) innerClass.get(NodeConstants.INNER_NAME);
-            ValueNode<Integer> accessNode = (ValueNode<Integer>) innerClass.get(NodeConstants.ACCESS);
+            ValueNode nameNode = (ValueNode) innerClass.get(NodeConstants.NAME);
+            ValueNode outerNameNode = (ValueNode) innerClass.get(NodeConstants.OUTER_NAME);
+            ValueNode innerNameNode = (ValueNode) innerClass.get(NodeConstants.INNER_NAME);
+            ValueNode accessNode = (ValueNode) innerClass.get(NodeConstants.ACCESS);
 
-            String name = nameNode.getValue();
-            String outerName = outerNameNode == null ? null : outerNameNode.getValue();
-            String innerName = innerNameNode == null ? null : innerNameNode.getValue();
-            int access = accessNode.getValue();
+            String name = nameNode.getValueAsString();
+            String outerName = outerNameNode == null ? null : outerNameNode.getValueAsString();
+            String innerName = innerNameNode == null ? null : innerNameNode.getValueAsString();
+            int access = accessNode.getValueAsInt();
 
             visitor.visitInnerClass(name, outerName, innerName, access);
         }
@@ -129,7 +128,7 @@ public class ClassNodeReader {
             return;
         }
         for (Node n : permittedSubclassesListNode) {
-            visitor.visitPermittedSubclass(((ValueNode<String>) n).getValue());
+            visitor.visitPermittedSubclass(((ValueNode) n).getValueAsString());
         }
     }
 
@@ -139,7 +138,7 @@ public class ClassNodeReader {
             return;
         }
         for (Node n : nestMembersListNode) {
-            visitor.visitNestMember(((ValueNode<String>) n).getValue());
+            visitor.visitNestMember(((ValueNode) n).getValueAsString());
         }
     }
 
@@ -149,7 +148,7 @@ public class ClassNodeReader {
             return;
         }
         for (Node n : attributesListNode) {
-            visitor.visitAttribute(((ValueNode<Attribute>) n).getValue());
+            visitor.visitAttribute(((ValueNode) n).getValueAs(Attribute.class));
         }
     }
 
@@ -166,28 +165,28 @@ public class ClassNodeReader {
 
     private void visitOuterClass(ClassVisitor visitor) {
         if (classNode.containsKey(NodeConstants.OWNER_CLASS)) {
-            String ownerClass = ((ValueNode<String>) classNode.get(NodeConstants.OWNER_CLASS)).getValue();
-            String ownerMethod = ((ValueNode<String>) classNode.get(NodeConstants.OWNER_METHOD)).getValue();
-            String ownerDescriptor = ((ValueNode<String>) classNode.get(NodeConstants.OWNER_DESCRIPTOR)).getValue();
+            String ownerClass = ((ValueNode) classNode.get(NodeConstants.OWNER_CLASS)).getValueAsString();
+            String ownerMethod = ((ValueNode) classNode.get(NodeConstants.OWNER_METHOD)).getValueAsString();
+            String ownerDescriptor = ((ValueNode) classNode.get(NodeConstants.OWNER_DESCRIPTOR)).getValueAsString();
             visitor.visitOuterClass(ownerClass, ownerMethod, ownerDescriptor);
         }
     }
 
     private void visitNestHost(ClassVisitor visitor) {
         if (classNode.containsKey(NodeConstants.NEST_HOST)) {
-            visitor.visitNestHost(((ValueNode<String>) classNode.get(NodeConstants.NEST_HOST)).getValue());
+            visitor.visitNestHost(((ValueNode) classNode.get(NodeConstants.NEST_HOST)).getValueAsString());
         }
     }
 
     private void visitSource(ClassVisitor visitor) {
         String source = null;
         if (classNode.containsKey(NodeConstants.SOURCE)) {
-            source = ((ValueNode<String>) classNode.get(NodeConstants.SOURCE)).getValue();
+            source = ((ValueNode) classNode.get(NodeConstants.SOURCE)).getValueAsString();
         }
 
         String debug = null;
         if (classNode.containsKey(NodeConstants.DEBUG)) {
-            debug = ((ValueNode<String>) classNode.get(NodeConstants.DEBUG)).getValue();
+            debug = ((ValueNode) classNode.get(NodeConstants.DEBUG)).getValueAsString();
         }
 
         visitor.visitSource(source, debug);

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/tree/reader/ClassNodeReader.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/tree/reader/ClassNodeReader.java
@@ -24,20 +24,20 @@ public class ClassNodeReader {
         }
 
         // visit
-        int version = ((ValueNode) classNode.get(NodeConstants.VERSION)).getValueAsInt();
-        int access = ((ValueNode) classNode.get(NodeConstants.ACCESS)).getValueAsInt();
-        String name = ((ValueNode) classNode.get(NodeConstants.NAME)).getValueAsString();
+        int version = Node.asValue(classNode.get(NodeConstants.VERSION)).getValueAsInt();
+        int access = Node.asValue(classNode.get(NodeConstants.ACCESS)).getValueAsInt();
+        String name = Node.asValue(classNode.get(NodeConstants.NAME)).getValueAsString();
 
-        ValueNode signatureNode = (ValueNode) classNode.get(NodeConstants.SIGNATURE);
+        ValueNode signatureNode = Node.asValue(classNode.get(NodeConstants.SIGNATURE));
         String signature = signatureNode == null ? null : signatureNode.getValueAsString();
 
-        ValueNode superClassNode = (ValueNode) classNode.get(NodeConstants.SUPER);
+        ValueNode superClassNode = Node.asValue(classNode.get(NodeConstants.SUPER));
         String superClass = superClassNode == null ? "java/lang/Object" : superClassNode.getValueAsString();
 
-        ListNode interfacesNode = (ListNode) classNode.get(NodeConstants.INTERFACES);
+        ListNode interfacesNode = Node.asList(classNode.get(NodeConstants.INTERFACES));
         String[] interfaces = interfacesNode == null ? new String[0]
                 :
-                interfacesNode.stream().map(n -> ((ValueNode) n).getValueAsString()).toArray(String[]::new);
+                interfacesNode.stream().map(n -> Node.asValue(n).getValueAsString()).toArray(String[]::new);
 
         visitor.visit(version, access, name, signature, superClass, interfaces);
 
@@ -46,7 +46,7 @@ public class ClassNodeReader {
 
         // visitModule
         if (classNode.containsKey(NodeConstants.MODULE)) {
-            ModuleNodeReader moduleWriter = new ModuleNodeReader((MapNode) classNode.get(NodeConstants.MODULE));
+            ModuleNodeReader moduleWriter = new ModuleNodeReader(Node.asMap(classNode.get(NodeConstants.MODULE)));
             moduleWriter.visitModule(visitor);
         }
         // visitNestHost
@@ -71,28 +71,28 @@ public class ClassNodeReader {
         visitInnerClasses(visitor);
 
         // visitRecordComponent
-        ListNode recordComponentListNode = (ListNode) classNode.get(NodeConstants.RECORD_COMPONENTS);
+        ListNode recordComponentListNode = Node.asList(classNode.get(NodeConstants.RECORD_COMPONENTS));
         if (recordComponentListNode != null) {
             for (Node node : recordComponentListNode) {
-                RecordComponentNodeReader recordComponentNodeReader = new RecordComponentNodeReader((MapNode) node);
+                RecordComponentNodeReader recordComponentNodeReader = new RecordComponentNodeReader(Node.asMap(node));
                 recordComponentNodeReader.visitRecordComponent(visitor);
             }
         }
 
         // visitField
-        ListNode fieldListNode = (ListNode) classNode.get(NodeConstants.FIELDS);
+        ListNode fieldListNode = Node.asList(classNode.get(NodeConstants.FIELDS));
         if (fieldListNode != null) {
             for (Node node : fieldListNode) {
-                FieldNodeReader fieldNodeReader = new FieldNodeReader((MapNode) node);
+                FieldNodeReader fieldNodeReader = new FieldNodeReader(Node.asMap(node));
                 fieldNodeReader.visitField(visitor);
             }
         }
 
         // visitMethod
-        ListNode methodListNode = (ListNode) classNode.get(NodeConstants.METHODS);
+        ListNode methodListNode = Node.asList(classNode.get(NodeConstants.METHODS));
         if (methodListNode != null) {
             for (Node node : methodListNode) {
-                MethodNodeReader methodNodeReader = new MethodNodeReader((MapNode) node);
+                MethodNodeReader methodNodeReader = new MethodNodeReader(Node.asMap(node));
                 methodNodeReader.visitMethod(visitor);
             }
         }
@@ -102,16 +102,16 @@ public class ClassNodeReader {
     }
 
     private void visitInnerClasses(ClassVisitor visitor) {
-        ListNode innerClassesListNode = (ListNode) classNode.get(NodeConstants.INNER_CLASSES);
+        ListNode innerClassesListNode = Node.asList(classNode.get(NodeConstants.INNER_CLASSES));
         if (innerClassesListNode == null) {
             return;
         }
         for (Node n : innerClassesListNode) {
-            MapNode innerClass = (MapNode) n;
-            ValueNode nameNode = (ValueNode) innerClass.get(NodeConstants.NAME);
-            ValueNode outerNameNode = (ValueNode) innerClass.get(NodeConstants.OUTER_NAME);
-            ValueNode innerNameNode = (ValueNode) innerClass.get(NodeConstants.INNER_NAME);
-            ValueNode accessNode = (ValueNode) innerClass.get(NodeConstants.ACCESS);
+            MapNode innerClass = Node.asMap(n);
+            ValueNode nameNode = Node.asValue(innerClass.get(NodeConstants.NAME));
+            ValueNode outerNameNode = Node.asValue(innerClass.get(NodeConstants.OUTER_NAME));
+            ValueNode innerNameNode = Node.asValue(innerClass.get(NodeConstants.INNER_NAME));
+            ValueNode accessNode = Node.asValue(innerClass.get(NodeConstants.ACCESS));
 
             String name = nameNode.getValueAsString();
             String outerName = outerNameNode == null ? null : outerNameNode.getValueAsString();
@@ -123,37 +123,37 @@ public class ClassNodeReader {
     }
 
     private void visitPermittedSubclasses(ClassVisitor visitor) {
-        ListNode permittedSubclassesListNode = (ListNode) classNode.get(NodeConstants.PERMITTED_SUBCLASSES);
+        ListNode permittedSubclassesListNode = Node.asList(classNode.get(NodeConstants.PERMITTED_SUBCLASSES));
         if (permittedSubclassesListNode == null) {
             return;
         }
         for (Node n : permittedSubclassesListNode) {
-            visitor.visitPermittedSubclass(((ValueNode) n).getValueAsString());
+            visitor.visitPermittedSubclass(Node.asValue(n).getValueAsString());
         }
     }
 
     private void visitNestMembers(ClassVisitor visitor) {
-        ListNode nestMembersListNode = (ListNode) classNode.get(NodeConstants.NEST_MEMBERS);
+        ListNode nestMembersListNode = Node.asList(classNode.get(NodeConstants.NEST_MEMBERS));
         if (nestMembersListNode == null) {
             return;
         }
         for (Node n : nestMembersListNode) {
-            visitor.visitNestMember(((ValueNode) n).getValueAsString());
+            visitor.visitNestMember(Node.asValue(n).getValueAsString());
         }
     }
 
     private void visitAttributes(ClassVisitor visitor) {
-        ListNode attributesListNode = (ListNode) classNode.get(NodeConstants.ATTRIBUTES);
+        ListNode attributesListNode = Node.asList(classNode.get(NodeConstants.ATTRIBUTES));
         if (attributesListNode == null) {
             return;
         }
         for (Node n : attributesListNode) {
-            visitor.visitAttribute(((ValueNode) n).getValueAs(Attribute.class));
+            visitor.visitAttribute(Node.asValue(n).getValueAs(Attribute.class));
         }
     }
 
     private void visitAnnotations(ClassVisitor visitor) {
-        ListNode annotationsListNode = (ListNode) classNode.get(NodeConstants.ANNOTATIONS);
+        ListNode annotationsListNode = Node.asList(classNode.get(NodeConstants.ANNOTATIONS));
         if (annotationsListNode == null) {
             return;
         }
@@ -165,28 +165,28 @@ public class ClassNodeReader {
 
     private void visitOuterClass(ClassVisitor visitor) {
         if (classNode.containsKey(NodeConstants.OWNER_CLASS)) {
-            String ownerClass = ((ValueNode) classNode.get(NodeConstants.OWNER_CLASS)).getValueAsString();
-            String ownerMethod = ((ValueNode) classNode.get(NodeConstants.OWNER_METHOD)).getValueAsString();
-            String ownerDescriptor = ((ValueNode) classNode.get(NodeConstants.OWNER_DESCRIPTOR)).getValueAsString();
+            String ownerClass = Node.asValue(classNode.get(NodeConstants.OWNER_CLASS)).getValueAsString();
+            String ownerMethod = Node.asValue(classNode.get(NodeConstants.OWNER_METHOD)).getValueAsString();
+            String ownerDescriptor = Node.asValue(classNode.get(NodeConstants.OWNER_DESCRIPTOR)).getValueAsString();
             visitor.visitOuterClass(ownerClass, ownerMethod, ownerDescriptor);
         }
     }
 
     private void visitNestHost(ClassVisitor visitor) {
         if (classNode.containsKey(NodeConstants.NEST_HOST)) {
-            visitor.visitNestHost(((ValueNode) classNode.get(NodeConstants.NEST_HOST)).getValueAsString());
+            visitor.visitNestHost(Node.asValue(classNode.get(NodeConstants.NEST_HOST)).getValueAsString());
         }
     }
 
     private void visitSource(ClassVisitor visitor) {
         String source = null;
         if (classNode.containsKey(NodeConstants.SOURCE)) {
-            source = ((ValueNode) classNode.get(NodeConstants.SOURCE)).getValueAsString();
+            source = Node.asValue(classNode.get(NodeConstants.SOURCE)).getValueAsString();
         }
 
         String debug = null;
         if (classNode.containsKey(NodeConstants.DEBUG)) {
-            debug = ((ValueNode) classNode.get(NodeConstants.DEBUG)).getValueAsString();
+            debug = Node.asValue(classNode.get(NodeConstants.DEBUG)).getValueAsString();
         }
 
         visitor.visitSource(source, debug);

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/tree/reader/FieldNodeReader.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/tree/reader/FieldNodeReader.java
@@ -17,17 +17,17 @@ public class FieldNodeReader {
     }
 
     private void visitAttributes(FieldVisitor fieldVisitor) {
-        ListNode attributesListNode = (ListNode) fieldNode.get(NodeConstants.ATTRIBUTES);
+        ListNode attributesListNode = Node.asList(fieldNode.get(NodeConstants.ATTRIBUTES));
         if (attributesListNode == null) {
             return;
         }
         for (Node n : attributesListNode) {
-            fieldVisitor.visitAttribute(((ValueNode) n).getValueAs(Attribute.class));
+            fieldVisitor.visitAttribute(Node.asValue(n).getValueAs(Attribute.class));
         }
     }
 
     private void visitAnnotations(FieldVisitor fieldVisitor) {
-        ListNode annotationsListNode = (ListNode) fieldNode.get(NodeConstants.ANNOTATIONS);
+        ListNode annotationsListNode = Node.asList(fieldNode.get(NodeConstants.ANNOTATIONS));
         if (annotationsListNode == null) {
             return;
         }
@@ -38,14 +38,14 @@ public class FieldNodeReader {
     }
 
     public void visitField(ClassVisitor visitor) {
-        int access = ((ValueNode) fieldNode.get(NodeConstants.ACCESS)).getValueAsInt();
-        String name = ((ValueNode) fieldNode.get(NodeConstants.NAME)).getValueAsString();
-        String descriptor = ((ValueNode) fieldNode.get(NodeConstants.DESCRIPTOR)).getValueAsString();
+        int access = Node.asValue(fieldNode.get(NodeConstants.ACCESS)).getValueAsInt();
+        String name = Node.asValue(fieldNode.get(NodeConstants.NAME)).getValueAsString();
+        String descriptor = Node.asValue(fieldNode.get(NodeConstants.DESCRIPTOR)).getValueAsString();
 
-        ValueNode signatureNode = (ValueNode) fieldNode.get(NodeConstants.SIGNATURE);
+        ValueNode signatureNode = Node.asValue(fieldNode.get(NodeConstants.SIGNATURE));
         String signature = signatureNode == null ? null : signatureNode.getValueAsString();
 
-        ValueNode valueNode = (ValueNode) fieldNode.get(NodeConstants.VALUE);
+        ValueNode valueNode = Node.asValue(fieldNode.get(NodeConstants.VALUE));
         Object value = valueNode == null ? null : valueNode.getValue();
 
         FieldVisitor fieldVisitor = visitor.visitField(access, name, descriptor, signature, value);

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/tree/reader/FieldNodeReader.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/tree/reader/FieldNodeReader.java
@@ -9,7 +9,6 @@ import org.quiltmc.chasm.api.tree.Node;
 import org.quiltmc.chasm.api.tree.ValueNode;
 import org.quiltmc.chasm.internal.util.NodeConstants;
 
-@SuppressWarnings("unchecked")
 public class FieldNodeReader {
     private final MapNode fieldNode;
 
@@ -23,7 +22,7 @@ public class FieldNodeReader {
             return;
         }
         for (Node n : attributesListNode) {
-            fieldVisitor.visitAttribute(((ValueNode<Attribute>) n).getValue());
+            fieldVisitor.visitAttribute(((ValueNode) n).getValueAs(Attribute.class));
         }
     }
 
@@ -39,14 +38,14 @@ public class FieldNodeReader {
     }
 
     public void visitField(ClassVisitor visitor) {
-        int access = ((ValueNode<Integer>) fieldNode.get(NodeConstants.ACCESS)).getValue();
-        String name = ((ValueNode<String>) fieldNode.get(NodeConstants.NAME)).getValue();
-        String descriptor = ((ValueNode<String>) fieldNode.get(NodeConstants.DESCRIPTOR)).getValue();
+        int access = ((ValueNode) fieldNode.get(NodeConstants.ACCESS)).getValueAsInt();
+        String name = ((ValueNode) fieldNode.get(NodeConstants.NAME)).getValueAsString();
+        String descriptor = ((ValueNode) fieldNode.get(NodeConstants.DESCRIPTOR)).getValueAsString();
 
-        ValueNode<String> signatureNode = (ValueNode<String>) fieldNode.get(NodeConstants.SIGNATURE);
-        String signature = signatureNode == null ? null : signatureNode.getValue();
+        ValueNode signatureNode = (ValueNode) fieldNode.get(NodeConstants.SIGNATURE);
+        String signature = signatureNode == null ? null : signatureNode.getValueAsString();
 
-        ValueNode<Object> valueNode = (ValueNode<Object>) fieldNode.get(NodeConstants.VALUE);
+        ValueNode valueNode = (ValueNode) fieldNode.get(NodeConstants.VALUE);
         Object value = valueNode == null ? null : valueNode.getValue();
 
         FieldVisitor fieldVisitor = visitor.visitField(access, name, descriptor, signature, value);

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/tree/reader/MethodNodeReader.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/tree/reader/MethodNodeReader.java
@@ -17,7 +17,6 @@ import org.quiltmc.chasm.api.tree.Node;
 import org.quiltmc.chasm.api.tree.ValueNode;
 import org.quiltmc.chasm.internal.util.NodeConstants;
 
-@SuppressWarnings("unchecked")
 public class MethodNodeReader {
     private final MapNode methodNode;
 
@@ -29,14 +28,14 @@ public class MethodNodeReader {
         Object[] arguments = new Object[argumentNode.size()];
         for (int i = 0; i < arguments.length; i++) {
             Node argNode = argumentNode.get(i);
-            if (argNode instanceof ValueNode<?>) {
-                arguments[i] = ((ValueNode<?>) argNode).getValue();
+            if (argNode instanceof ValueNode) {
+                arguments[i] = ((ValueNode) argNode).getValue();
             } else if (((MapNode) argNode).containsKey(NodeConstants.TAG)) {
                 arguments[i] = getHandle((MapNode) argNode);
             } else {
                 MapNode constDynamicNode = (MapNode) argNode;
-                String name = ((ValueNode<String>) constDynamicNode.get(NodeConstants.NAME)).getValue();
-                String descriptor = ((ValueNode<String>) constDynamicNode.get(NodeConstants.DESCRIPTOR)).getValue();
+                String name = ((ValueNode) constDynamicNode.get(NodeConstants.NAME)).getValueAsString();
+                String descriptor = ((ValueNode) constDynamicNode.get(NodeConstants.DESCRIPTOR)).getValueAsString();
                 Handle handle = getHandle((MapNode) constDynamicNode.get(NodeConstants.HANDLE));
                 Object[] args = getArguments((ListNode) constDynamicNode.get(NodeConstants.ARGS));
                 arguments[i] = new ConstantDynamic(name, descriptor, handle, args);
@@ -47,11 +46,11 @@ public class MethodNodeReader {
     }
 
     public static Handle getHandle(MapNode handleNode) {
-        int tag = ((ValueNode<Integer>) handleNode.get(NodeConstants.TAG)).getValue();
-        String owner = ((ValueNode<String>) handleNode.get(NodeConstants.OWNER)).getValue();
-        String name = ((ValueNode<String>) handleNode.get(NodeConstants.NAME)).getValue();
-        String descriptor = ((ValueNode<String>) handleNode.get(NodeConstants.DESCRIPTOR)).getValue();
-        boolean isInterface = ((ValueNode<Boolean>) handleNode.get(NodeConstants.IS_INTERFACE)).getValue();
+        int tag = ((ValueNode) handleNode.get(NodeConstants.TAG)).getValueAsInt();
+        String owner = ((ValueNode) handleNode.get(NodeConstants.OWNER)).getValueAsString();
+        String name = ((ValueNode) handleNode.get(NodeConstants.NAME)).getValueAsString();
+        String descriptor = ((ValueNode) handleNode.get(NodeConstants.DESCRIPTOR)).getValueAsString();
+        boolean isInterface = ((ValueNode) handleNode.get(NodeConstants.IS_INTERFACE)).getValueAsBoolean();
 
         return new Handle(tag, owner, name, descriptor, isInterface);
     }
@@ -66,13 +65,13 @@ public class MethodNodeReader {
 
             // visitLabel
             if (instruction.containsKey(NodeConstants.LABEL)) {
-                String label = ((ValueNode<String>) instruction.get(NodeConstants.LABEL)).getValue();
+                String label = ((ValueNode) instruction.get(NodeConstants.LABEL)).getValueAsString();
                 methodVisitor.visitLabel(obtainLabel(labelMap, label));
                 continue;
             }
 
             // visit<...>Insn
-            int opcode = ((ValueNode<Integer>) instruction.get(NodeConstants.OPCODE)).getValue();
+            int opcode = ((ValueNode) instruction.get(NodeConstants.OPCODE)).getValueAsInt();
             switch (opcode) {
                 case Opcodes.NOP:
                     // TODO Hack to strip the trailing NOP
@@ -191,7 +190,7 @@ public class MethodNodeReader {
                 case Opcodes.SIPUSH:
                 case Opcodes.NEWARRAY: {
                     // visitIntInsn
-                    int operand = ((ValueNode<Integer>) instruction.get(NodeConstants.OPERAND)).getValue();
+                    int operand = ((ValueNode) instruction.get(NodeConstants.OPERAND)).getValueAsInt();
                     methodVisitor.visitIntInsn(opcode, operand);
                     break;
                 }
@@ -207,7 +206,7 @@ public class MethodNodeReader {
                 case Opcodes.ASTORE:
                 case Opcodes.RET: {
                     // visitVarInsn
-                    int varIndex = ((ValueNode<Integer>) instruction.get(NodeConstants.VAR)).getValue();
+                    int varIndex = ((ValueNode) instruction.get(NodeConstants.VAR)).getValueAsInt();
                     methodVisitor.visitVarInsn(opcode, varIndex);
                     break;
                 }
@@ -216,7 +215,7 @@ public class MethodNodeReader {
                 case Opcodes.CHECKCAST:
                 case Opcodes.INSTANCEOF: {
                     // visitTypeInsn
-                    String type = ((ValueNode<String>) instruction.get(NodeConstants.TYPE)).getValue();
+                    String type = ((ValueNode) instruction.get(NodeConstants.TYPE)).getValueAsString();
                     methodVisitor.visitTypeInsn(opcode, type);
                     break;
                 }
@@ -225,10 +224,10 @@ public class MethodNodeReader {
                 case Opcodes.GETFIELD:
                 case Opcodes.PUTFIELD: {
                     // visitFieldInsn
-                    String owner = ((ValueNode<String>) instruction.get(NodeConstants.OWNER)).getValue();
-                    String name1 = ((ValueNode<String>) instruction.get(NodeConstants.NAME)).getValue();
+                    String owner = ((ValueNode) instruction.get(NodeConstants.OWNER)).getValueAsString();
+                    String name1 = ((ValueNode) instruction.get(NodeConstants.NAME)).getValueAsString();
                     String descriptor1 =
-                            ((ValueNode<String>) instruction.get(NodeConstants.DESCRIPTOR)).getValue();
+                            ((ValueNode) instruction.get(NodeConstants.DESCRIPTOR)).getValueAsString();
                     methodVisitor.visitFieldInsn(opcode, owner, name1, descriptor1);
                     break;
                 }
@@ -237,20 +236,20 @@ public class MethodNodeReader {
                 case Opcodes.INVOKESTATIC:
                 case Opcodes.INVOKEINTERFACE: {
                     // visitMethodInsns
-                    String owner = ((ValueNode<String>) instruction.get(NodeConstants.OWNER)).getValue();
-                    String name1 = ((ValueNode<String>) instruction.get(NodeConstants.NAME)).getValue();
+                    String owner = ((ValueNode) instruction.get(NodeConstants.OWNER)).getValueAsString();
+                    String name1 = ((ValueNode) instruction.get(NodeConstants.NAME)).getValueAsString();
                     String descriptor1 =
-                            ((ValueNode<String>) instruction.get(NodeConstants.DESCRIPTOR)).getValue();
-                    Boolean isInterface =
-                            ((ValueNode<Boolean>) instruction.get(NodeConstants.IS_INTERFACE)).getValue();
+                            ((ValueNode) instruction.get(NodeConstants.DESCRIPTOR)).getValueAsString();
+                    boolean isInterface =
+                            ((ValueNode) instruction.get(NodeConstants.IS_INTERFACE)).getValueAsBoolean();
                     methodVisitor.visitMethodInsn(opcode, owner, name1, descriptor1, isInterface);
                     break;
                 }
                 case Opcodes.INVOKEDYNAMIC: {
                     // visitInvokeDynamicInsn
-                    String name1 = ((ValueNode<String>) instruction.get(NodeConstants.NAME)).getValue();
+                    String name1 = ((ValueNode) instruction.get(NodeConstants.NAME)).getValueAsString();
                     String descriptor1 =
-                            ((ValueNode<String>) instruction.get(NodeConstants.DESCRIPTOR)).getValue();
+                            ((ValueNode) instruction.get(NodeConstants.DESCRIPTOR)).getValueAsString();
                     Handle handle = getHandle((MapNode) instruction.get(NodeConstants.HANDLE));
                     Object[] arguments = getArguments((ListNode) instruction.get(NodeConstants.ARGUMENTS));
                     methodVisitor.visitInvokeDynamicInsn(name1, descriptor1, handle, arguments);
@@ -275,21 +274,21 @@ public class MethodNodeReader {
                 case Opcodes.IFNULL:
                 case Opcodes.IFNONNULL: {
                     // visitJumpInsns
-                    String labelString = ((ValueNode<String>) instruction.get(NodeConstants.TARGET)).getValue();
+                    String labelString = ((ValueNode) instruction.get(NodeConstants.TARGET)).getValueAsString();
                     Label label = obtainLabel(labelMap, labelString);
                     methodVisitor.visitJumpInsn(opcode, label);
                     break;
                 }
                 case Opcodes.LDC: {
                     // visitLdcInsn
-                    Object value = ((ValueNode<Object>) instruction.get(NodeConstants.VALUE)).getValue();
+                    Object value = ((ValueNode) instruction.get(NodeConstants.VALUE)).getValue();
                     methodVisitor.visitLdcInsn(value);
                     break;
                 }
                 case Opcodes.IINC: {
                     // visitIincInsn
-                    int varIndex = ((ValueNode<Integer>) instruction.get(NodeConstants.VAR)).getValue();
-                    int increment = ((ValueNode<Integer>) instruction.get(NodeConstants.INCREMENT)).getValue();
+                    int varIndex = ((ValueNode) instruction.get(NodeConstants.VAR)).getValueAsInt();
+                    int increment = ((ValueNode) instruction.get(NodeConstants.INCREMENT)).getValueAsInt();
                     methodVisitor.visitIincInsn(varIndex, increment);
                     break;
                 }
@@ -297,15 +296,15 @@ public class MethodNodeReader {
                 case Opcodes.LOOKUPSWITCH: {
                     // visitTableSwitchInsn / visitLookupSwitchInsn
                     String defaultString =
-                            ((ValueNode<String>) instruction.get(NodeConstants.DEFAULT)).getValue();
+                            ((ValueNode) instruction.get(NodeConstants.DEFAULT)).getValueAsString();
                     Label dflt = obtainLabel(labelMap, defaultString);
                     ListNode cases = (ListNode) instruction.get(NodeConstants.CASES);
                     int[] keys = new int[cases.size()];
                     Label[] labels = new Label[cases.size()];
                     for (int i = 0; i < cases.size(); i++) {
                         MapNode caseNode = (MapNode) cases.get(i);
-                        keys[i] = ((ValueNode<Integer>) caseNode.get(NodeConstants.KEY)).getValue();
-                        String caseLabelString = ((ValueNode<String>) caseNode.get(NodeConstants.LABEL)).getValue();
+                        keys[i] = ((ValueNode) caseNode.get(NodeConstants.KEY)).getValueAsInt();
+                        String caseLabelString = ((ValueNode) caseNode.get(NodeConstants.LABEL)).getValueAsString();
                         labels[i] = obtainLabel(labelMap, caseLabelString);
                     }
 
@@ -333,8 +332,8 @@ public class MethodNodeReader {
                 case Opcodes.MULTIANEWARRAY: {
                     // visitMultiANewArrayInsn
                     String descriptor1 =
-                            ((ValueNode<String>) instruction.get(NodeConstants.DESCRIPTOR)).getValue();
-                    int dimensions = ((ValueNode<Integer>) instruction.get(NodeConstants.DIMENSIONS)).getValue();
+                            ((ValueNode) instruction.get(NodeConstants.DESCRIPTOR)).getValueAsString();
+                    int dimensions = ((ValueNode) instruction.get(NodeConstants.DIMENSIONS)).getValueAsInt();
                     methodVisitor.visitMultiANewArrayInsn(descriptor1, dimensions);
                     break;
                 }
@@ -362,10 +361,10 @@ public class MethodNodeReader {
         for (Node n : tryCatchBlocksListNode) {
             MapNode tryCatchBlock = (MapNode) n;
 
-            String start = ((ValueNode<String>) tryCatchBlock.get(NodeConstants.START)).getValue();
-            String end = ((ValueNode<String>) tryCatchBlock.get(NodeConstants.END)).getValue();
-            String handler = ((ValueNode<String>) tryCatchBlock.get(NodeConstants.HANDLER)).getValue();
-            String type = ((ValueNode<String>) tryCatchBlock.get(NodeConstants.TYPE)).getValue();
+            String start = ((ValueNode) tryCatchBlock.get(NodeConstants.START)).getValueAsString();
+            String end = ((ValueNode) tryCatchBlock.get(NodeConstants.END)).getValueAsString();
+            String handler = ((ValueNode) tryCatchBlock.get(NodeConstants.HANDLER)).getValueAsString();
+            String type = ((ValueNode) tryCatchBlock.get(NodeConstants.TYPE)).getValueAsString();
 
             Label startLabel = labelMap.computeIfAbsent(start, s -> new Label());
             Label endLabel = labelMap.computeIfAbsent(end, s -> new Label());
@@ -388,15 +387,15 @@ public class MethodNodeReader {
         }
         for (Node n : codeLocalsNode) {
             MapNode localNode = (MapNode) n;
-            String localName = ((ValueNode<String>) localNode.get(NodeConstants.NAME)).getValue();
-            String localDesc = ((ValueNode<String>) localNode.get(NodeConstants.DESCRIPTOR)).getValue();
+            String localName = ((ValueNode) localNode.get(NodeConstants.NAME)).getValueAsString();
+            String localDesc = ((ValueNode) localNode.get(NodeConstants.DESCRIPTOR)).getValueAsString();
 
-            ValueNode<String> localSignatureNode = (ValueNode<String>) localNode.get(NodeConstants.SIGNATURE);
-            String localSignature = localSignatureNode == null ? localDesc : localSignatureNode.getValue();
+            ValueNode localSignatureNode = (ValueNode) localNode.get(NodeConstants.SIGNATURE);
+            String localSignature = localSignatureNode == null ? localDesc : localSignatureNode.getValueAsString();
 
-            String start = ((ValueNode<String>) localNode.get(NodeConstants.START)).getValue();
-            String end = ((ValueNode<String>) localNode.get(NodeConstants.END)).getValue();
-            int index = ((ValueNode<Integer>) localNode.get(NodeConstants.INDEX)).getValue();
+            String start = ((ValueNode) localNode.get(NodeConstants.START)).getValueAsString();
+            String end = ((ValueNode) localNode.get(NodeConstants.END)).getValueAsString();
+            int index = ((ValueNode) localNode.get(NodeConstants.INDEX)).getValueAsInt();
 
             Label startLabel = labelMap.get(start);
             Label endLabel = labelMap.get(end);
@@ -414,8 +413,8 @@ public class MethodNodeReader {
         if (lineNumbers != null) {
             for (Node n : lineNumbers) {
                 MapNode lineNumber = (MapNode) n;
-                int line = ((ValueNode<Integer>) lineNumber.get(NodeConstants.LINE)).getValue();
-                String labelName = ((ValueNode<String>) lineNumber.get(NodeConstants.LABEL)).getValue();
+                int line = ((ValueNode) lineNumber.get(NodeConstants.LINE)).getValueAsInt();
+                String labelName = ((ValueNode) lineNumber.get(NodeConstants.LABEL)).getValueAsString();
                 Label label = labelMap.get(labelName);
                 if (label != null) {
                     methodVisitor.visitLineNumber(line, label);
@@ -428,7 +427,7 @@ public class MethodNodeReader {
         ListNode methodAttributesNode = (ListNode) methodNode.get(NodeConstants.ATTRIBUTES);
         if (methodAttributesNode != null) {
             for (Node n : methodAttributesNode) {
-                methodVisitor.visitAttribute(((ValueNode<Attribute>) n).getValue());
+                methodVisitor.visitAttribute(((ValueNode) n).getValueAs(Attribute.class));
             }
         }
     }
@@ -464,13 +463,13 @@ public class MethodNodeReader {
         }
         for (Node n : parameterAnnotationsListNode) {
             MapNode annotationNode = (MapNode) n;
-            int parameter = ((ValueNode<Integer>) annotationNode.get(NodeConstants.PARAMETER)).getValue();
-            String annotationDesc = ((ValueNode<String>) annotationNode.get(NodeConstants.DESCRIPTOR)).getValue();
+            int parameter = ((ValueNode) annotationNode.get(NodeConstants.PARAMETER)).getValueAsInt();
+            String annotationDesc = ((ValueNode) annotationNode.get(NodeConstants.DESCRIPTOR)).getValueAsString();
 
-            ValueNode<Boolean> methodAnnotationVisibilityNode = (ValueNode<Boolean>) annotationNode
+            ValueNode methodAnnotationVisibilityNode = (ValueNode) annotationNode
                     .get(NodeConstants.VISIBLE);
             boolean visible = methodAnnotationVisibilityNode == null
-                    || methodAnnotationVisibilityNode.getValue();
+                    || methodAnnotationVisibilityNode.getValueAsBoolean();
 
             AnnotationNodeReader writer = new AnnotationNodeReader(n);
             AnnotationVisitor annotationVisitor =
@@ -496,23 +495,23 @@ public class MethodNodeReader {
         }
         for (Node n : methodParametersNode) {
             MapNode parameterNode = (MapNode) n;
-            String parameterName = ((ValueNode<String>) parameterNode.get(NodeConstants.NAME)).getValue();
-            int parameterAccess = ((ValueNode<Integer>) parameterNode.get(NodeConstants.ACCESS)).getValue();
+            String parameterName = ((ValueNode) parameterNode.get(NodeConstants.NAME)).getValueAsString();
+            int parameterAccess = ((ValueNode) parameterNode.get(NodeConstants.ACCESS)).getValueAsInt();
             methodVisitor.visitParameter(parameterName, parameterAccess);
         }
     }
 
     public void visitMethod(ClassVisitor visitor) {
-        int access = ((ValueNode<Integer>) methodNode.get(NodeConstants.ACCESS)).getValue();
-        String name = ((ValueNode<String>) methodNode.get(NodeConstants.NAME)).getValue();
-        String descriptor = ((ValueNode<String>) methodNode.get(NodeConstants.DESCRIPTOR)).getValue();
+        int access = ((ValueNode) methodNode.get(NodeConstants.ACCESS)).getValueAsInt();
+        String name = ((ValueNode) methodNode.get(NodeConstants.NAME)).getValueAsString();
+        String descriptor = ((ValueNode) methodNode.get(NodeConstants.DESCRIPTOR)).getValueAsString();
 
-        ValueNode<String> signatureNode = (ValueNode<String>) methodNode.get(NodeConstants.SIGNATURE);
-        String signature = signatureNode == null ? null : signatureNode.getValue();
+        ValueNode signatureNode = (ValueNode) methodNode.get(NodeConstants.SIGNATURE);
+        String signature = signatureNode == null ? null : signatureNode.getValueAsString();
 
         ListNode exceptionsNode = (ListNode) methodNode.get(NodeConstants.EXCEPTIONS);
         String[] exceptions = exceptionsNode == null ? new String[0]
-                : exceptionsNode.stream().map(n -> ((ValueNode<String>) n).getValue()).toArray(String[]::new);
+                : exceptionsNode.stream().map(n -> ((ValueNode) n).getValueAsString()).toArray(String[]::new);
         MethodVisitor methodVisitor = visitor.visitMethod(access, name, descriptor, signature, exceptions);
 
         // visitParameter

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/tree/reader/ModuleNodeReader.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/tree/reader/ModuleNodeReader.java
@@ -8,7 +8,6 @@ import org.quiltmc.chasm.api.tree.Node;
 import org.quiltmc.chasm.api.tree.ValueNode;
 import org.quiltmc.chasm.internal.util.NodeConstants;
 
-@SuppressWarnings("unchecked")
 public class ModuleNodeReader {
     private final MapNode moduleNode;
 
@@ -17,10 +16,10 @@ public class ModuleNodeReader {
     }
 
     public void visitModule(ClassVisitor visitor) {
-        String name = ((ValueNode<String>) moduleNode.get(NodeConstants.NAME)).getValue();
-        int access = ((ValueNode<Integer>) moduleNode.get(NodeConstants.ACCESS)).getValue();
-        ValueNode<String> versionNode = (ValueNode<String>) moduleNode.get(NodeConstants.VERSION);
-        String version = versionNode == null ? null : versionNode.getValue();
+        String name = ((ValueNode) moduleNode.get(NodeConstants.NAME)).getValueAsString();
+        int access = ((ValueNode) moduleNode.get(NodeConstants.ACCESS)).getValueAsInt();
+        ValueNode versionNode = (ValueNode) moduleNode.get(NodeConstants.VERSION);
+        String version = versionNode == null ? null : versionNode.getValueAsString();
 
         ModuleVisitor moduleVisitor = visitor.visitModule(name, access, version);
 
@@ -51,7 +50,7 @@ public class ModuleNodeReader {
 
     private void visitMainClass(ModuleVisitor moduleVisitor) {
         if (moduleNode.containsKey(NodeConstants.MAIN)) {
-            moduleVisitor.visitMainClass(((ValueNode<String>) moduleNode.get(NodeConstants.MAIN)).getValue());
+            moduleVisitor.visitMainClass(((ValueNode) moduleNode.get(NodeConstants.MAIN)).getValueAsString());
         }
     }
 
@@ -62,7 +61,7 @@ public class ModuleNodeReader {
             return;
         }
         for (Node n : packagesListNode) {
-            moduleVisitor.visitPackage(((ValueNode<String>) n).getValue());
+            moduleVisitor.visitPackage(((ValueNode) n).getValueAsString());
         }
     }
 
@@ -73,11 +72,11 @@ public class ModuleNodeReader {
         }
         for (Node n : moduleRequiresListNode) {
             MapNode requireNode = (MapNode) n;
-            String reqModule = ((ValueNode<String>) requireNode.get(NodeConstants.MODULE)).getValue();
-            int reqAccess = ((ValueNode<Integer>) requireNode.get(NodeConstants.ACCESS)).getValue();
+            String reqModule = ((ValueNode) requireNode.get(NodeConstants.MODULE)).getValueAsString();
+            int reqAccess = ((ValueNode) requireNode.get(NodeConstants.ACCESS)).getValueAsInt();
 
-            ValueNode<String> versionNode = (ValueNode<String>) requireNode.get(NodeConstants.VERSION);
-            String reqVersion = versionNode == null ? null : versionNode.getValue();
+            ValueNode versionNode = (ValueNode) requireNode.get(NodeConstants.VERSION);
+            String reqVersion = versionNode == null ? null : versionNode.getValueAsString();
             moduleVisitor.visitRequire(reqModule, reqAccess, reqVersion);
         }
     }
@@ -89,14 +88,14 @@ public class ModuleNodeReader {
         }
         for (Node n : moduleExportsListNode) {
             MapNode exportNode = (MapNode) n;
-            String expPackage = ((ValueNode<String>) exportNode.get(NodeConstants.PACKAGE)).getValue();
-            Integer expAcccess = ((ValueNode<Integer>) exportNode.get(NodeConstants.ACCESS)).getValue();
+            String expPackage = ((ValueNode) exportNode.get(NodeConstants.PACKAGE)).getValueAsString();
+            Integer expAcccess = ((ValueNode) exportNode.get(NodeConstants.ACCESS)).getValueAsInt();
             ListNode reqModules = ((ListNode) exportNode.get(NodeConstants.MODULES));
             String[] modules = null;
             if (reqModules != null) {
                 modules = new String[reqModules.size()];
                 for (int i = 0; i < reqModules.size(); i++) {
-                    modules[i] = ((ValueNode<String>) reqModules.get(i)).getValue();
+                    modules[i] = ((ValueNode) reqModules.get(i)).getValueAsString();
                 }
             }
             moduleVisitor.visitExport(expPackage, expAcccess, modules);
@@ -110,15 +109,15 @@ public class ModuleNodeReader {
         }
         for (Node n : moduleOpensListNode) {
             MapNode openNode = (MapNode) n;
-            String openPackage = ((ValueNode<String>) openNode.get(NodeConstants.PACKAGE)).getValue();
-            Integer openAccess = ((ValueNode<Integer>) openNode.get(NodeConstants.ACCESS)).getValue();
+            String openPackage = ((ValueNode) openNode.get(NodeConstants.PACKAGE)).getValueAsString();
+            Integer openAccess = ((ValueNode) openNode.get(NodeConstants.ACCESS)).getValueAsInt();
 
             ListNode openModules = ((ListNode) openNode.get(NodeConstants.MODULES));
             String[] modules = null;
             if (openModules != null) {
                 modules = new String[openModules.size()];
                 for (int i = 0; i < openModules.size(); i++) {
-                    modules[i] = ((ValueNode<String>) openModules.get(i)).getValue();
+                    modules[i] = ((ValueNode) openModules.get(i)).getValueAsString();
                 }
             }
 
@@ -132,7 +131,7 @@ public class ModuleNodeReader {
             return;
         }
         for (Node n : moduleUsesListNode) {
-            moduleVisitor.visitUse(((ValueNode<String>) n).getValue());
+            moduleVisitor.visitUse(((ValueNode) n).getValueAsString());
         }
     }
 
@@ -143,11 +142,11 @@ public class ModuleNodeReader {
         }
         for (Node n : moduleProvidesListNode) {
             MapNode providesNode = (MapNode) n;
-            String service = ((ValueNode<String>) providesNode.get(NodeConstants.SERVICE)).getValue();
+            String service = ((ValueNode) providesNode.get(NodeConstants.SERVICE)).getValueAsString();
             ListNode providers = (ListNode) providesNode.get(NodeConstants.PROVIDERS);
             String[] prov = new String[providers.size()];
             for (int i = 0; i < providers.size(); i++) {
-                prov[i] = ((ValueNode<String>) providers.get(i)).getValue();
+                prov[i] = ((ValueNode) providers.get(i)).getValueAsString();
             }
             moduleVisitor.visitProvide(service, prov);
         }

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/tree/reader/ModuleNodeReader.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/tree/reader/ModuleNodeReader.java
@@ -16,9 +16,9 @@ public class ModuleNodeReader {
     }
 
     public void visitModule(ClassVisitor visitor) {
-        String name = ((ValueNode) moduleNode.get(NodeConstants.NAME)).getValueAsString();
-        int access = ((ValueNode) moduleNode.get(NodeConstants.ACCESS)).getValueAsInt();
-        ValueNode versionNode = (ValueNode) moduleNode.get(NodeConstants.VERSION);
+        String name = Node.asValue(moduleNode.get(NodeConstants.NAME)).getValueAsString();
+        int access = Node.asValue(moduleNode.get(NodeConstants.ACCESS)).getValueAsInt();
+        ValueNode versionNode = Node.asValue(moduleNode.get(NodeConstants.VERSION));
         String version = versionNode == null ? null : versionNode.getValueAsString();
 
         ModuleVisitor moduleVisitor = visitor.visitModule(name, access, version);
@@ -50,52 +50,52 @@ public class ModuleNodeReader {
 
     private void visitMainClass(ModuleVisitor moduleVisitor) {
         if (moduleNode.containsKey(NodeConstants.MAIN)) {
-            moduleVisitor.visitMainClass(((ValueNode) moduleNode.get(NodeConstants.MAIN)).getValueAsString());
+            moduleVisitor.visitMainClass(Node.asValue(moduleNode.get(NodeConstants.MAIN)).getValueAsString());
         }
     }
 
     private void visitPackages(ModuleVisitor moduleVisitor) {
         // https://docs.oracle.com/javase/specs/jvms/se17/html/jvms-4.html#jvms-4.7.26
-        ListNode packagesListNode = (ListNode) moduleNode.get(NodeConstants.PACKAGES);
+        ListNode packagesListNode = Node.asList(moduleNode.get(NodeConstants.PACKAGES));
         if (packagesListNode == null) {
             return;
         }
         for (Node n : packagesListNode) {
-            moduleVisitor.visitPackage(((ValueNode) n).getValueAsString());
+            moduleVisitor.visitPackage(Node.asValue(n).getValueAsString());
         }
     }
 
     private void visitRequires(ModuleVisitor moduleVisitor) {
-        ListNode moduleRequiresListNode = (ListNode) moduleNode.get(NodeConstants.REQUIRES);
+        ListNode moduleRequiresListNode = Node.asList(moduleNode.get(NodeConstants.REQUIRES));
         if (moduleRequiresListNode == null) {
             return;
         }
         for (Node n : moduleRequiresListNode) {
-            MapNode requireNode = (MapNode) n;
-            String reqModule = ((ValueNode) requireNode.get(NodeConstants.MODULE)).getValueAsString();
-            int reqAccess = ((ValueNode) requireNode.get(NodeConstants.ACCESS)).getValueAsInt();
+            MapNode requireNode = Node.asMap(n);
+            String reqModule = Node.asValue(requireNode.get(NodeConstants.MODULE)).getValueAsString();
+            int reqAccess = Node.asValue(requireNode.get(NodeConstants.ACCESS)).getValueAsInt();
 
-            ValueNode versionNode = (ValueNode) requireNode.get(NodeConstants.VERSION);
+            ValueNode versionNode = Node.asValue(requireNode.get(NodeConstants.VERSION));
             String reqVersion = versionNode == null ? null : versionNode.getValueAsString();
             moduleVisitor.visitRequire(reqModule, reqAccess, reqVersion);
         }
     }
 
     private void visitExports(ModuleVisitor moduleVisitor) {
-        ListNode moduleExportsListNode = (ListNode) moduleNode.get(NodeConstants.EXPORTS);
+        ListNode moduleExportsListNode = Node.asList(moduleNode.get(NodeConstants.EXPORTS));
         if (moduleExportsListNode == null) {
             return;
         }
         for (Node n : moduleExportsListNode) {
-            MapNode exportNode = (MapNode) n;
-            String expPackage = ((ValueNode) exportNode.get(NodeConstants.PACKAGE)).getValueAsString();
-            Integer expAcccess = ((ValueNode) exportNode.get(NodeConstants.ACCESS)).getValueAsInt();
-            ListNode reqModules = ((ListNode) exportNode.get(NodeConstants.MODULES));
+            MapNode exportNode = Node.asMap(n);
+            String expPackage = Node.asValue(exportNode.get(NodeConstants.PACKAGE)).getValueAsString();
+            Integer expAcccess = Node.asValue(exportNode.get(NodeConstants.ACCESS)).getValueAsInt();
+            ListNode reqModules = (Node.asList(exportNode.get(NodeConstants.MODULES)));
             String[] modules = null;
             if (reqModules != null) {
                 modules = new String[reqModules.size()];
                 for (int i = 0; i < reqModules.size(); i++) {
-                    modules[i] = ((ValueNode) reqModules.get(i)).getValueAsString();
+                    modules[i] = Node.asValue(reqModules.get(i)).getValueAsString();
                 }
             }
             moduleVisitor.visitExport(expPackage, expAcccess, modules);
@@ -103,21 +103,21 @@ public class ModuleNodeReader {
     }
 
     private void visitOpens(ModuleVisitor moduleVisitor) {
-        ListNode moduleOpensListNode = (ListNode) moduleNode.get(NodeConstants.OPENS);
+        ListNode moduleOpensListNode = Node.asList(moduleNode.get(NodeConstants.OPENS));
         if (moduleOpensListNode == null) {
             return;
         }
         for (Node n : moduleOpensListNode) {
-            MapNode openNode = (MapNode) n;
-            String openPackage = ((ValueNode) openNode.get(NodeConstants.PACKAGE)).getValueAsString();
-            Integer openAccess = ((ValueNode) openNode.get(NodeConstants.ACCESS)).getValueAsInt();
+            MapNode openNode = Node.asMap(n);
+            String openPackage = Node.asValue(openNode.get(NodeConstants.PACKAGE)).getValueAsString();
+            Integer openAccess = Node.asValue(openNode.get(NodeConstants.ACCESS)).getValueAsInt();
 
-            ListNode openModules = ((ListNode) openNode.get(NodeConstants.MODULES));
+            ListNode openModules = (Node.asList(openNode.get(NodeConstants.MODULES)));
             String[] modules = null;
             if (openModules != null) {
                 modules = new String[openModules.size()];
                 for (int i = 0; i < openModules.size(); i++) {
-                    modules[i] = ((ValueNode) openModules.get(i)).getValueAsString();
+                    modules[i] = Node.asValue(openModules.get(i)).getValueAsString();
                 }
             }
 
@@ -126,27 +126,27 @@ public class ModuleNodeReader {
     }
 
     private void visitUses(ModuleVisitor moduleVisitor) {
-        ListNode moduleUsesListNode = (ListNode) moduleNode.get(NodeConstants.USES);
+        ListNode moduleUsesListNode = Node.asList(moduleNode.get(NodeConstants.USES));
         if (moduleUsesListNode == null) {
             return;
         }
         for (Node n : moduleUsesListNode) {
-            moduleVisitor.visitUse(((ValueNode) n).getValueAsString());
+            moduleVisitor.visitUse(Node.asValue(n).getValueAsString());
         }
     }
 
     private void visitProvides(ModuleVisitor moduleVisitor) {
-        ListNode moduleProvidesListNode = (ListNode) moduleNode.get(NodeConstants.PROVIDES);
+        ListNode moduleProvidesListNode = Node.asList(moduleNode.get(NodeConstants.PROVIDES));
         if (moduleProvidesListNode == null) {
             return;
         }
         for (Node n : moduleProvidesListNode) {
-            MapNode providesNode = (MapNode) n;
-            String service = ((ValueNode) providesNode.get(NodeConstants.SERVICE)).getValueAsString();
-            ListNode providers = (ListNode) providesNode.get(NodeConstants.PROVIDERS);
+            MapNode providesNode = Node.asMap(n);
+            String service = Node.asValue(providesNode.get(NodeConstants.SERVICE)).getValueAsString();
+            ListNode providers = Node.asList(providesNode.get(NodeConstants.PROVIDERS));
             String[] prov = new String[providers.size()];
             for (int i = 0; i < providers.size(); i++) {
-                prov[i] = ((ValueNode) providers.get(i)).getValueAsString();
+                prov[i] = Node.asValue(providers.get(i)).getValueAsString();
             }
             moduleVisitor.visitProvide(service, prov);
         }

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/tree/reader/RecordComponentNodeReader.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/tree/reader/RecordComponentNodeReader.java
@@ -17,17 +17,17 @@ public class RecordComponentNodeReader {
     }
 
     private void visitAttributes(RecordComponentVisitor componentVisitor) {
-        ListNode attributesListNode = (ListNode) componentNode.get(NodeConstants.ATTRIBUTES);
+        ListNode attributesListNode = Node.asList(componentNode.get(NodeConstants.ATTRIBUTES));
         if (attributesListNode == null) {
             return;
         }
         for (Node n : attributesListNode) {
-            componentVisitor.visitAttribute(((ValueNode) n).getValueAs(Attribute.class));
+            componentVisitor.visitAttribute(Node.asValue(n).getValueAs(Attribute.class));
         }
     }
 
     private void visitAnnotations(RecordComponentVisitor componentVisitor) {
-        ListNode annotationsListNode = (ListNode) componentNode.get(NodeConstants.ANNOTATIONS);
+        ListNode annotationsListNode = Node.asList(componentNode.get(NodeConstants.ANNOTATIONS));
         if (annotationsListNode == null) {
             return;
         }
@@ -38,10 +38,10 @@ public class RecordComponentNodeReader {
     }
 
     public void visitRecordComponent(ClassVisitor visitor) {
-        String name = ((ValueNode) componentNode.get(NodeConstants.NAME)).getValueAsString();
-        String descriptor = ((ValueNode) componentNode.get(NodeConstants.DESCRIPTOR)).getValueAsString();
+        String name = Node.asValue(componentNode.get(NodeConstants.NAME)).getValueAsString();
+        String descriptor = Node.asValue(componentNode.get(NodeConstants.DESCRIPTOR)).getValueAsString();
 
-        ValueNode signatureNode = (ValueNode) componentNode.get(NodeConstants.SIGNATURE);
+        ValueNode signatureNode = Node.asValue(componentNode.get(NodeConstants.SIGNATURE));
         String signature = signatureNode == null ? null : signatureNode.getValueAsString();
 
         RecordComponentVisitor componentVisitor = visitor.visitRecordComponent(name, descriptor, signature);

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/tree/reader/RecordComponentNodeReader.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/tree/reader/RecordComponentNodeReader.java
@@ -9,7 +9,6 @@ import org.quiltmc.chasm.api.tree.Node;
 import org.quiltmc.chasm.api.tree.ValueNode;
 import org.quiltmc.chasm.internal.util.NodeConstants;
 
-@SuppressWarnings("unchecked")
 public class RecordComponentNodeReader {
     private final MapNode componentNode;
 
@@ -23,7 +22,7 @@ public class RecordComponentNodeReader {
             return;
         }
         for (Node n : attributesListNode) {
-            componentVisitor.visitAttribute(((ValueNode<Attribute>) n).getValue());
+            componentVisitor.visitAttribute(((ValueNode) n).getValueAs(Attribute.class));
         }
     }
 
@@ -39,11 +38,11 @@ public class RecordComponentNodeReader {
     }
 
     public void visitRecordComponent(ClassVisitor visitor) {
-        String name = ((ValueNode<String>) componentNode.get(NodeConstants.NAME)).getValue();
-        String descriptor = ((ValueNode<String>) componentNode.get(NodeConstants.DESCRIPTOR)).getValue();
+        String name = ((ValueNode) componentNode.get(NodeConstants.NAME)).getValueAsString();
+        String descriptor = ((ValueNode) componentNode.get(NodeConstants.DESCRIPTOR)).getValueAsString();
 
-        ValueNode<String> signatureNode = (ValueNode<String>) componentNode.get(NodeConstants.SIGNATURE);
-        String signature = signatureNode == null ? null : signatureNode.getValue();
+        ValueNode signatureNode = (ValueNode) componentNode.get(NodeConstants.SIGNATURE);
+        String signature = signatureNode == null ? null : signatureNode.getValueAsString();
 
         RecordComponentVisitor componentVisitor = visitor.visitRecordComponent(name, descriptor, signature);
 

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/util/NodeUtils.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/util/NodeUtils.java
@@ -1,0 +1,18 @@
+package org.quiltmc.chasm.internal.util;
+
+import org.quiltmc.chasm.api.tree.Node;
+import org.quiltmc.chasm.internal.metadata.PathMetadata;
+
+public class NodeUtils {
+    private NodeUtils() {
+    }
+
+    public static IllegalStateException createWrongTypeException(Node node, String expectedType) {
+        PathMetadata pathMeta = node.getMetadata().get(PathMetadata.class);
+        if (pathMeta == null) {
+            return new IllegalStateException("Node is not a " + expectedType + "!");
+        } else {
+            return new IllegalStateException("Node " + pathMeta + " is not a " + expectedType + "!");
+        }
+    }
+}

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/util/PathInitializer.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/util/PathInitializer.java
@@ -30,14 +30,14 @@ public abstract class PathInitializer {
                 initialize(fullNode, path);
             }
         } else if (root instanceof MapNode) {
-            MapNode mapNode = (MapNode) root;
+            MapNode mapNode = Node.asMap(root);
 
             // Recursively set the path for all entries
             for (Map.Entry<String, Node> entry : mapNode.entrySet()) {
                 initialize(entry.getValue(), path.append(entry.getKey()));
             }
         } else if (root instanceof ListNode) {
-            ListNode listNode = (ListNode) root;
+            ListNode listNode = Node.asList(root);
 
             // Recursively set the path for all entries
             for (int i = 0; i < listNode.size(); i++) {

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/util/TreePrinter.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/util/TreePrinter.java
@@ -29,8 +29,8 @@ public class TreePrinter {
     }
 
     private void print(Node node, int indent) {
-        if (node instanceof ValueNode<?>) {
-            ValueNode<?> valueNode = (ValueNode<?>) node;
+        if (node instanceof ValueNode) {
+            ValueNode valueNode = (ValueNode) node;
             if (valueNode.getValue() instanceof String) {
                 printStream.print("\"" + valueNode.getValue() + "\"");
             } else {

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/util/TreePrinter.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/util/TreePrinter.java
@@ -38,7 +38,7 @@ public class TreePrinter {
             }
         } else if (node instanceof ListNode) {
             printStream.println("[");
-            for (Node entry : (ListNode) node) {
+            for (Node entry : Node.asList(node)) {
                 printIndent(indent + 1);
                 print(entry, indent + 1);
                 printStream.println(",");
@@ -50,7 +50,7 @@ public class TreePrinter {
                 printStream.print("LazyClassNode<" + ((LazyClassNode) node).getClassReader().getClassName() + ">");
             } else {
                 printStream.println("{");
-                for (Map.Entry<String, Node> entry : ((MapNode) node).entrySet()) {
+                for (Map.Entry<String, Node> entry : (Node.asMap(node)).entrySet()) {
                     printIndent(indent + 1);
                     printStream.print("\"" + entry.getKey() + "\"" + ": ");
                     print(entry.getValue(), indent + 1);

--- a/chasm/src/test/java/org/quiltmc/chasm/transformer/field/AddField.java
+++ b/chasm/src/test/java/org/quiltmc/chasm/transformer/field/AddField.java
@@ -34,8 +34,8 @@ public class AddField implements Transformer {
 
         List<Transformation> transformations = new ArrayList<>();
         for (Node node : classes) {
-            MapNode classNode = (MapNode) node;
-            ListNode fieldsNode = (ListNode) classNode.get(NodeConstants.FIELDS);
+            MapNode classNode = Node.asMap(node);
+            ListNode fieldsNode = Node.asList(classNode.get(NodeConstants.FIELDS));
             SliceTarget sliceTarget = new SliceTarget(fieldsNode, 0, 0);
             transformations.add(new Transformation(this, sliceTarget, Map.of(), (target, sources) -> newFields));
         }

--- a/chasm/src/test/java/org/quiltmc/chasm/transformer/field/AddField.java
+++ b/chasm/src/test/java/org/quiltmc/chasm/transformer/field/AddField.java
@@ -21,11 +21,11 @@ public class AddField implements Transformer {
     @Override
     public Collection<Transformation> apply(ListNode classes) {
         MapNode newFieldNode = new LinkedHashMapNode();
-        newFieldNode.put(NodeConstants.ACCESS, new ValueNode<>(Opcodes.ACC_PUBLIC));
-        newFieldNode.put(NodeConstants.NAME, new ValueNode<>("field1"));
-        newFieldNode.put(NodeConstants.DESCRIPTOR, new ValueNode<>("I"));
-        newFieldNode.put(NodeConstants.SIGNATURE, new ValueNode<>(null));
-        newFieldNode.put(NodeConstants.VALUE, new ValueNode<>(null));
+        newFieldNode.put(NodeConstants.ACCESS, new ValueNode(Opcodes.ACC_PUBLIC));
+        newFieldNode.put(NodeConstants.NAME, new ValueNode("field1"));
+        newFieldNode.put(NodeConstants.DESCRIPTOR, new ValueNode("I"));
+        newFieldNode.put(NodeConstants.SIGNATURE, new ValueNode(null));
+        newFieldNode.put(NodeConstants.VALUE, new ValueNode(null));
         newFieldNode.put(NodeConstants.ANNOTATIONS, new ArrayListNode());
         newFieldNode.put(NodeConstants.ATTRIBUTES, new ArrayListNode());
 


### PR DESCRIPTION
Closes #33.

This also adds `getValueAs(Class)`, which allows getting the value with checked casting.
`getValueAsInt()`, `getValueAsBoolean()`, and `getValueAsString()` are convenience methods which call `getValueAs(Class)` (and also handle unboxing, in the case of the former two).