### PR TITLE
Basic evaluation error tracing, implement toString for all AST nodes

### DIFF
--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/LambdaNode.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/LambdaNode.java
@@ -48,6 +48,10 @@ public class LambdaNode extends Node {
     @Override
     @ApiStatus.OverrideOnly
     public Node evaluate(Evaluator evaluator) {
-        return evaluator.createClosure(this);
+        evaluator.pushTrace(this, "lambda ("+this.identifier+")");
+        Node result = evaluator.createClosure(this);
+        evaluator.popTrace();
+
+        return result;
     }
 }

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/ListNode.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/ListNode.java
@@ -30,8 +30,12 @@ public class ListNode extends Node {
     public Node evaluate(Evaluator evaluator) {
         List<Node> newEntries = new ArrayList<>();
 
-        for (Node entry : entries) {
+        for (int i = 0; i < entries.size(); i++) {
+            Node entry = entries.get(i);
+
+            evaluator.pushTrace(entry, "list entry ["+i+"]");
             newEntries.add(entry.evaluate(evaluator));
+            evaluator.popTrace();
         }
 
         if (newEntries.equals(entries)) {

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/MapNode.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/MapNode.java
@@ -54,7 +54,9 @@ public class MapNode extends Node {
         Map<String, Node> newEntries = new LinkedHashMap<>();
 
         for (Map.Entry<String, Node> entry : entries.entrySet()) {
+            evaluator.pushTrace(entry.getValue(), "map entry \""+entry.getKey()+"\"");
             newEntries.put(entry.getKey(), entry.getValue().evaluate(evaluator));
+            evaluator.popTrace();
         }
 
         if (newEntries.equals(entries)) {

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/MemberNode.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/MemberNode.java
@@ -60,6 +60,12 @@ public class MemberNode extends Node {
             return NullNode.INSTANCE;
         }
 
-        return entries.get(identifier).evaluate(evaluator);
+        Node entry = entries.get(identifier);
+
+        evaluator.pushTrace(entry, "member \""+this.identifier+"\"");
+        Node result = entry.evaluate(evaluator);
+        evaluator.popTrace();
+
+        return result;
     }
 }

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/Node.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/Node.java
@@ -16,6 +16,8 @@ import org.quiltmc.chasm.lang.internal.render.Renderer;
  * This class can be extended by an execution environment if it requires special behaviour for custom nodes.
  */
 public abstract class Node {
+    private static final Renderer renderer = Renderer.builder().trailingCommas(false).build();
+
     @ApiStatus.OverrideOnly
     public abstract void resolve(Resolver resolver);
 
@@ -53,5 +55,13 @@ public abstract class Node {
         StringBuilder sb = new StringBuilder();
         render(renderer, sb, 1);
         Files.write(path, sb.toString().getBytes()); // what about utf16 support?
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName() + " "
+                + renderer.render(this)
+                        .replaceAll("\n", "") // Remove trailing newline at the end of render
+                + " @" + Integer.toHexString(this.hashCode());
     }
 }

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/NullNode.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/NullNode.java
@@ -6,4 +6,9 @@ public final class NullNode extends ValueNode<Void> {
     private NullNode() {
         super(null);
     }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName() + " @" + Integer.toHexString(this.hashCode());
+    }
 }

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/ReferenceNode.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/ReferenceNode.java
@@ -46,7 +46,11 @@ public class ReferenceNode extends Node {
             throw new EvaluationException("Failed to resolve reference: " + this);
         }
 
-        return resolved.evaluate(evaluator);
+        evaluator.pushTrace(resolved, this.global ? "global ref <" : "ref <"+this.identifier+">");
+        Node result = resolved.evaluate(evaluator);
+        evaluator.popTrace();
+
+        return result;
     }
 
     @Override
@@ -60,6 +64,7 @@ public class ReferenceNode extends Node {
 
     @Override
     public String toString() {
-        return "Ref<" + identifier + ">";
+        return this.getClass().getSimpleName()
+                + (this.global ? " <$" : " <") + this.identifier + "> @" + Integer.toHexString(this.hashCode());
     }
 }

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/ValueNode.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/ValueNode.java
@@ -31,7 +31,7 @@ public abstract class ValueNode<T> extends Node {
 
     @Override
     public String toString() {
-        return String.valueOf(value);
+        return this.getClass().getSimpleName() + " " + this.value + " @" + Integer.toHexString(this.hashCode());
     }
 
     @Override

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/eval/Evaluator.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/eval/Evaluator.java
@@ -1,6 +1,7 @@
 package org.quiltmc.chasm.lang.api.eval;
 
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 import org.quiltmc.chasm.lang.api.ast.LambdaNode;
 import org.quiltmc.chasm.lang.api.ast.Node;
 import org.quiltmc.chasm.lang.api.ast.ReferenceNode;
@@ -17,4 +18,10 @@ public interface Evaluator {
     ClosureNode createClosure(LambdaNode lambdaNode);
 
     Node callClosure(ClosureNode closure, Node arg);
+
+    void pushTrace(Node beingEvaluated, String traceEntry);
+
+    void popTrace();
+
+    String renderTrace();
 }

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/exception/EvaluationException.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/exception/EvaluationException.java
@@ -1,7 +1,16 @@
 package org.quiltmc.chasm.lang.api.exception;
 
+import org.quiltmc.chasm.lang.api.eval.Evaluator;
+
 public class EvaluationException extends RuntimeException {
     public EvaluationException(String message) {
         super(message);
+    }
+
+    public EvaluationException withTraceback(Evaluator evaluator) {
+        EvaluationException ex = new EvaluationException(this.getMessage() + "\n " + evaluator.renderTrace());
+        ex.setStackTrace(this.getStackTrace());
+
+        return ex;
     }
 }


### PR DESCRIPTION
This (draft) PR aims to make Chassembly's error reporting more intuitive and readable.

Currently implemented features:
- Default `toString` implementations for all nodes
- More detailed evaluation errors, with a traceback of all code leading up to the error