### PR TITLE
Fix trailing commas

### DIFF
--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/internal/parse/Parser.jj
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/internal/parse/Parser.jj
@@ -114,6 +114,7 @@ Node listExpression():
             e = expression()
             { entries.add(e); }
             (
+                LOOKAHEAD(2)
                 <Comma>
                 e = expression()
                 { entries.add(e); }
@@ -140,6 +141,7 @@ Node mapExpression():
             e = expression()
             { entries.put(t.getImage(), e); }
             (
+                LOOKAHEAD(2)
                 <Comma>
                 t = <Identifier>
                 <Colon>

--- a/chassembly/src/test/resources/results/syntax/trailing_commas.chasm
+++ b/chassembly/src/test/resources/results/syntax/trailing_commas.chasm
@@ -1,0 +1,14 @@
+{
+    list: [1,2,3,], 
+    list_multiline: [1,2,3,], 
+    object: {
+        a: 1, 
+        b: 2, 
+        c: 3, 
+    }, 
+    object_multiline: {
+        a: 1, 
+        b: 2, 
+        c: 3, 
+    }, 
+}

--- a/chassembly/src/test/resources/tests/syntax/trailing_commas.chasm
+++ b/chassembly/src/test/resources/tests/syntax/trailing_commas.chasm
@@ -1,0 +1,14 @@
+{
+    list: [1, 2, 3,],
+    list_multiline: [
+        1,
+        2,
+        3,
+    ],
+    object: { a: 1, b:2, c:3 },
+    object_multiline: {
+        a: 1,
+        b: 2,
+        c: 3,
+    }
+}


### PR DESCRIPTION
This PR adds extra lookahead to parsing maps and lists, fixing trailing commas.
It also adds a matching test.