### PR TITLE
Reference literals

### DIFF
--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/MapNode.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/MapNode.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import org.jetbrains.annotations.ApiStatus;
 import org.quiltmc.chasm.lang.api.eval.Evaluator;
 import org.quiltmc.chasm.lang.api.eval.Resolver;
+import org.quiltmc.chasm.lang.internal.render.RenderUtil;
 import org.quiltmc.chasm.lang.internal.render.Renderer;
 
 public class MapNode extends Node {
@@ -29,11 +30,7 @@ public class MapNode extends Node {
         for (int i = 0; i < list.size(); i++) {
             renderer.indent(builder, currentIndentationMultiplier);
             String key = list.get(i).getKey();
-            if (needsQuotes(key)) {
-                builder.append('"').append(key.replace("\\", "\\\\").replace("\"", "\\\"")).append('"');
-            } else {
-                builder.append(key);
-            }
+            builder.append(RenderUtil.quotifyIdentifierIfNeeded(key, '"'));
             builder.append(": ");
             list.get(i).getValue().render(renderer, builder, currentIndentationMultiplier + 1);
             if (i < entries.size() - 1 || renderer.hasTrailingCommas()) {
@@ -44,32 +41,6 @@ public class MapNode extends Node {
             renderer.indent(builder, currentIndentationMultiplier - 1);
         }
         builder.append('}');
-    }
-
-    private static boolean needsQuotes(String key) {
-        if (key.isEmpty()) {
-            return true;
-        }
-
-        if (!isValidIdentifierStartChar(key.charAt(0))) {
-            return true;
-        }
-
-        for (int i = 1; i < key.length(); i++) {
-            if (!isValidIdentifierChar(key.charAt(i))) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private static boolean isValidIdentifierStartChar(char c) {
-        return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '_';
-    }
-
-    private static boolean isValidIdentifierChar(char c) {
-        return isValidIdentifierStartChar(c) || (c >= '0' && c <= '9');
     }
 
     @Override

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/MemberNode.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/MemberNode.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.quiltmc.chasm.lang.api.eval.Evaluator;
 import org.quiltmc.chasm.lang.api.eval.Resolver;
 import org.quiltmc.chasm.lang.api.exception.EvaluationException;
+import org.quiltmc.chasm.lang.internal.render.RenderUtil;
 import org.quiltmc.chasm.lang.internal.render.Renderer;
 
 public class MemberNode extends Node {
@@ -36,7 +37,7 @@ public class MemberNode extends Node {
     @Override
     public void render(Renderer renderer, StringBuilder builder, int currentIndentationMultiplier) {
         left.render(renderer, builder, currentIndentationMultiplier);
-        builder.append(".").append(identifier);
+        builder.append(".").append(RenderUtil.quotifyIdentifierIfNeeded(identifier, '`'));
     }
 
     @Override

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/ReferenceNode.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/ReferenceNode.java
@@ -4,6 +4,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.quiltmc.chasm.lang.api.eval.Evaluator;
 import org.quiltmc.chasm.lang.api.eval.Resolver;
 import org.quiltmc.chasm.lang.api.exception.EvaluationException;
+import org.quiltmc.chasm.lang.internal.render.RenderUtil;
 import org.quiltmc.chasm.lang.internal.render.Renderer;
 
 public class ReferenceNode extends Node {
@@ -55,7 +56,7 @@ public class ReferenceNode extends Node {
             builder.append("$");
         }
 
-        builder.append(identifier);
+        builder.append(RenderUtil.quotifyIdentifierIfNeeded(identifier, '`'));
     }
 
     @Override

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/ValueNode.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/ValueNode.java
@@ -3,6 +3,7 @@ package org.quiltmc.chasm.lang.api.ast;
 import org.jetbrains.annotations.ApiStatus;
 import org.quiltmc.chasm.lang.api.eval.Evaluator;
 import org.quiltmc.chasm.lang.api.eval.Resolver;
+import org.quiltmc.chasm.lang.internal.render.RenderUtil;
 import org.quiltmc.chasm.lang.internal.render.Renderer;
 
 public abstract class ValueNode<T> extends Node {
@@ -23,7 +24,7 @@ public abstract class ValueNode<T> extends Node {
     @Override
     public void render(Renderer renderer, StringBuilder builder, int currentIndentationMultiplier) {
         if (value instanceof String) {
-            builder.append('"').append(((String) value).replace("\\", "\\\\").replace("\"", "\\\"")).append('"');
+            builder.append(RenderUtil.quotify((String) value, '"'));
         } else {
             builder.append(value);
         }

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/internal/parse/Parser.jj
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/internal/parse/Parser.jj
@@ -29,7 +29,7 @@ import org.quiltmc.chasm.lang.api.ast.UnaryNode;
 import org.quiltmc.chasm.lang.internal.parse.SourceSpan;
 
 public class Parser {
-    private static String extractStringOrCharLiteral(String image) {
+    private static String extractTextualLiteral(String image) {
         StringBuilder sb = new StringBuilder(image.length() - 2);
         for (int i = 1, e = image.length() - 1; i < e; i++) {
             char c = image.charAt(i);
@@ -85,10 +85,10 @@ Node literalExpression():
         { n = new FloatNode(Double.parseDouble(t.getImage())); }
         |
         t = <StringLiteral>
-        { n = new StringNode(extractStringOrCharLiteral(t.getImage())); }
+        { n = new StringNode(extractTextualLiteral(t.getImage())); }
         |
         t = <CharLiteral>
-        { n = new IntegerNode((long) extractStringOrCharLiteral(t.getImage()).charAt(0)); }
+        { n = new IntegerNode((long) extractTextualLiteral(t.getImage()).charAt(0)); }
     )
 
     {
@@ -109,9 +109,13 @@ Node referenceExpression():
         "$"
         { g = true; }
     )?
-    t = <Identifier>
+    ( t = <Identifier> | t = <ReferenceLiteral> )
     {
-        Node n = new ReferenceNode(t.getImage(), g);
+        String s = t.getImage();
+        if (s.startsWith("`")) {
+            s = extractTextualLiteral(s);
+        }
+        Node n = new ReferenceNode(s, g);
         SourceSpan span = SourceSpan.fromToken(start).join(SourceSpan.fromToken(lastConsumedToken));
         n.getMetadata().put(SourceSpan.class, span);
         return n;
@@ -175,7 +179,7 @@ Node mapExpression():
                 { key = t.getImage(); }
                 |
                 t = <StringLiteral>
-                { key = extractStringOrCharLiteral(t.getImage()); }
+                { key = extractTextualLiteral(t.getImage()); }
             )
             <Colon>
             e = expression()
@@ -188,7 +192,7 @@ Node mapExpression():
                     { key = t.getImage(); }
                     |
                     t = <StringLiteral>
-                    { key = extractStringOrCharLiteral(t.getImage()); }
+                    { key = extractTextualLiteral(t.getImage()); }
                 )
                 <Colon>
                 e = expression()
@@ -260,9 +264,13 @@ Node argumentExpression():
         |
         (
             <Dot>
-            t = <Identifier>
+            ( t = <Identifier> | t = <ReferenceLiteral> )
             {
-                e = new MemberNode(e, t.getImage());
+                String s = t.getImage();
+                if (s.startsWith("`")) {
+                    s = extractTextualLiteral(s);
+                }
+                e = new MemberNode(e, s);
                 SourceSpan span = SourceSpan.fromToken(start).join(SourceSpan.fromToken(lastConsumedToken));
                 e.getMetadata().put(SourceSpan.class, span);
             }
@@ -634,6 +642,10 @@ TOKEN: {
     <#Char: ~["'", "\\"] | "\\'" | "\\\\" >
     |
     <CharLiteral: "'" <Char> "'" >
+    |
+    <#ReferenceLiteralChar: ~["`", "\\"] | "\\`" | "\\\\" >
+    |
+    <ReferenceLiteral: "`" (<ReferenceLiteralChar>)* "`" >
 }
 
 // Identifier

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/internal/render/RenderUtil.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/internal/render/RenderUtil.java
@@ -1,0 +1,40 @@
+package org.quiltmc.chasm.lang.internal.render;
+
+public class RenderUtil {
+    private RenderUtil() {
+    }
+
+    public static String quotify(String text, char quoteChar) {
+        return quoteChar + text.replace("\\", "\\\\").replace("" + quoteChar, "\\" + quoteChar) + quoteChar;
+    }
+
+    public static String quotifyIdentifierIfNeeded(String identifier, char quoteChar) {
+        return needsQuotes(identifier) ? quotify(identifier, quoteChar) : identifier;
+    }
+
+    private static boolean needsQuotes(String identifier) {
+        if (identifier.isEmpty()) {
+            return true;
+        }
+
+        if (!isValidIdentifierStartChar(identifier.charAt(0))) {
+            return true;
+        }
+
+        for (int i = 1; i < identifier.length(); i++) {
+            if (!isValidIdentifierChar(identifier.charAt(i))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static boolean isValidIdentifierStartChar(char c) {
+        return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '_';
+    }
+
+    private static boolean isValidIdentifierChar(char c) {
+        return isValidIdentifierStartChar(c) || (c >= '0' && c <= '9');
+    }
+}

--- a/chassembly/src/test/resources/results/complex/basic.chasm
+++ b/chassembly/src/test/resources/results/complex/basic.chasm
@@ -53,4 +53,5 @@
     shift_call: 250, 
     shifting: <Closure can't be rendered>, 
     xmas: "Hello World!", 
+    quoted_ref: 0, 
 }

--- a/chassembly/src/test/resources/results/literals/basic.chasm
+++ b/chassembly/src/test/resources/results/literals/basic.chasm
@@ -12,4 +12,5 @@
     backslash: 92, 
     single_quote: 39, 
     "quoted key": 0, 
+    quoted_key_ref: 0, 
 }

--- a/chassembly/src/test/resources/tests/complex/basic.chasm
+++ b/chassembly/src/test/resources/tests/complex/basic.chasm
@@ -32,5 +32,6 @@
     shift: x -> x << 1,
     shift_call: shift(125),
     shifting: x -> x << 1 ^ x >> 1,
-    xmas: "Hello " + "World" + "!"
+    xmas: "Hello " + "World" + "!",
+    quoted_ref: {"hello world": 0}.`hello world`,
 }

--- a/chassembly/src/test/resources/tests/literals/basic.chasm
+++ b/chassembly/src/test/resources/tests/literals/basic.chasm
@@ -12,4 +12,5 @@
     backslash: '\\',
     single_quote: '\'',
     "quoted key": 0,
+    quoted_key_ref: `quoted key`,
 }


### PR DESCRIPTION
Adds the ability to reference otherwise invalid identifiers using reference expressions and member expressions:
```json
{
   "invalid ident": 0,
   second_key: `invalid ident`,
   third_key: {"hello world": 0}.`hello world`,
}
```