### PR TITLE
Fix checkstyle to not require Javadoc on internal and test files, and…

### DIFF
--- a/chasm/src/main/java/org/quiltmc/chasm/api/Lock.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/api/Lock.java
@@ -1,5 +1,8 @@
 package org.quiltmc.chasm.api;
 
+/**
+ * Todo.
+ */
 public enum Lock {
     NONE,
     BEFORE,

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/intrinsic/FileBytesIntrinsic.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/intrinsic/FileBytesIntrinsic.java
@@ -27,7 +27,7 @@ public class FileBytesIntrinsic extends IntrinsicFunction {
                 "Built-in function \"file_bytes\" can only be applied to strings but found " + arg);
         }
         byte[] bytes = context.readFile(((StringNode) arg).getValue());
-        return bytes == null ? new NullNode() : new ListNode(IntStream.range(0, bytes.length)
+        return bytes == null ? NullNode.INSTANCE : new ListNode(IntStream.range(0, bytes.length)
                 .mapToObj(index -> new IntegerNode(bytes[index] & 0xff)).collect(Collectors.toList()));
     }
 

--- a/chasm/src/main/java/org/quiltmc/chasm/internal/intrinsic/FileContentIntrinsic.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/intrinsic/FileContentIntrinsic.java
@@ -21,7 +21,7 @@ public class FileContentIntrinsic extends IntrinsicFunction {
     @Override
     public Node apply(Evaluator evaluator, Node arg) {
         String content = readString(arg, context);
-        return content == null ? new NullNode() : new StringNode(content);
+        return content == null ? NullNode.INSTANCE : new StringNode(content);
     }
 
     @Override

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/Ast.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/Ast.java
@@ -66,7 +66,7 @@ public final class Ast {
      * @see NullNode
      */
     public static NullNode nullNode() {
-        return new NullNode();
+        return NullNode.INSTANCE;
     }
 
     /**

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/BinaryNode.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/BinaryNode.java
@@ -14,37 +14,63 @@ import org.quiltmc.chasm.lang.api.eval.Resolver;
 import org.quiltmc.chasm.lang.api.exception.EvaluationException;
 import org.quiltmc.chasm.lang.internal.render.Renderer;
 
+/**
+ * A binary expression, e.g. {@code foo + bar}.
+ */
 public class BinaryNode extends Node {
     private Node left;
     private Operator operator;
     private Node right;
 
+    /**
+     * Constructs a binary expression.
+     *
+     * @see Ast#binary(Node, Operator, Node)
+     */
     public BinaryNode(Node left, Operator operator, Node right) {
         this.left = left;
         this.operator = operator;
         this.right = right;
     }
 
+    /**
+     * Gets the left hand side of this binary expression.
+     */
     public Node getLeft() {
         return left;
     }
 
+    /**
+     * Sets the left hand side of this binary expression.
+     */
     public void setLeft(Node left) {
         this.left = left;
     }
 
+    /**
+     * Gets the right hand side of this binary expression.
+     */
     public Node getRight() {
         return right;
     }
 
+    /**
+     * Sets the right hand side of this binary expression.
+     */
     public void setRight(Node right) {
         this.right = right;
     }
 
+    /**
+     * Gets the operator of this binary expression.
+     */
     public Operator getOperator() {
         return operator;
     }
 
+    /**
+     * Sets the operator of this binary expression.
+     */
     public void setOperator(Operator operator) {
         this.operator = operator;
     }
@@ -395,25 +421,85 @@ public class BinaryNode extends Node {
         }
     }
 
+    /**
+     * The operator of a binary expression.
+     */
     public enum Operator {
+        /**
+         * The addition operator, {@code +}.
+         */
         PLUS("+", 4, false),
+        /**
+         * The subtraction operator, {@code -}.
+         */
         MINUS("-", 4, true),
+        /**
+         * The multiplication operator, {@code *}.
+         */
         MULTIPLY("*", 3, false),
+        /**
+         * The division operator, {@code /}.
+         */
         DIVIDE("/", 3, true),
+        /**
+         * The modulo operator, {@code %}.
+         */
         MODULO("%", 3, false),
+        /**
+         * The left shift operator, {@code <<}.
+         */
         SHIFT_LEFT("<<", 5, false),
+        /**
+         * The arithmetic right shift operator, {@code >>}.
+         */
         SHIFT_RIGHT(">>", 5, false),
+        /**
+         * The unsigned right shift operator, {@code >>>}.
+         */
         SHIFT_RIGHT_UNSIGNED(">>>", 5, false),
+        /**
+         * The less than operator, {@code <}.
+         */
         LESS_THAN("<", 6, false),
+        /**
+         * The less than or equal operator, {@code <=}.
+         */
         LESS_THAN_OR_EQUAL("<=", 6, false),
+        /**
+         * The greater than operator, {@code >}.
+         */
         GREATER_THAN(">", 6, false),
+        /**
+         * The greater than or equal operator, {@code >=}.
+         */
         GREATER_THAN_OR_EQUAL(">=", 6, false),
+        /**
+         * The equality operator, {@code =}.
+         */
         EQUAL("=", 7, false),
+        /**
+         * The inequality operator, {@code !=}.
+         */
         NOT_EQUAL("!=", 7, false),
+        /**
+         * The bitwise and operator, {@code &}.
+         */
         BITWISE_AND("&", 8, false),
+        /**
+         * The bitwise xor operator, {@code ^}.
+         */
         BITWISE_XOR("^", 9, false),
+        /**
+         * The bitwise or operator, {@code |}.
+         */
         BITWISE_OR("|", 10, false),
+        /**
+         * The boolean and operator, {@code &&}.
+         */
         BOOLEAN_AND("&&", 11, false),
+        /**
+         * The boolean or operator, {@code ||}.
+         */
         BOOLEAN_OR("||", 12, false);
 
         private final String image;
@@ -433,10 +519,16 @@ public class BinaryNode extends Node {
             this.requiresBracketsWithSelf = requiresBracketsWithSelf;
         }
 
+        /**
+         * The image of this operator, or the string that represents it in code.
+         */
         public String getImage() {
             return image;
         }
 
+        /**
+         * The precedence of the operator, lower values means it's evaluated first by default.
+         */
         public int getPrecedence() {
             return precedence;
         }
@@ -446,6 +538,9 @@ public class BinaryNode extends Node {
             return image;
         }
 
+        /**
+         * Returns whether this operator's precedence is greater than the given value.
+         */
         public boolean morePrecedenceThan(int precedence) {
             return this.precedence > precedence;
         }

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/BooleanNode.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/BooleanNode.java
@@ -1,13 +1,27 @@
 package org.quiltmc.chasm.lang.api.ast;
 
+/**
+ * A boolean literal expression.
+ */
 public final class BooleanNode extends ValueNode<Boolean> {
+    /**
+     * The boolean literal expression representing {@code true}.
+     */
     public static final BooleanNode TRUE = new BooleanNode(true);
+    /**
+     * The boolean literal expression representing {@code false}.
+     */
     public static final BooleanNode FALSE = new BooleanNode(false);
 
     private BooleanNode(Boolean value) {
         super(value);
     }
 
+    /**
+     * Returns the boolean literal expression representing the given value.
+     *
+     * @see Ast#literal(boolean)
+     */
     public static BooleanNode from(boolean value) {
         return value ? TRUE : FALSE;
     }

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/CallNode.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/CallNode.java
@@ -7,27 +7,47 @@ import org.quiltmc.chasm.lang.api.eval.Resolver;
 import org.quiltmc.chasm.lang.api.exception.EvaluationException;
 import org.quiltmc.chasm.lang.internal.render.Renderer;
 
+/**
+ * A call expression, representing function application.
+ */
 public class CallNode extends Node {
     private Node function;
     private Node arg;
 
+    /**
+     * Creates a call expression.
+     *
+     * @see Ast#call(Node, Node)
+     */
     public CallNode(Node function, Node arg) {
         this.function = function;
         this.arg = arg;
     }
 
+    /**
+     * Gets the function that is being applied.
+     */
     public Node getFunction() {
         return function;
     }
 
+    /**
+     * Sets the function that is being applied.
+     */
     public void setFunction(Node function) {
         this.function = function;
     }
 
+    /**
+     * Gets the argument to the application.
+     */
     public Node getArg() {
         return arg;
     }
 
+    /**
+     * Sets the argument to the application.
+     */
     public void setArg(Node arg) {
         this.arg = arg;
     }

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/FloatNode.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/FloatNode.java
@@ -1,10 +1,23 @@
 package org.quiltmc.chasm.lang.api.ast;
 
+/**
+ * A float literal expression.
+ */
 public final class FloatNode extends ValueNode<Double> {
+    /**
+     * Creates a float literal expression.
+     *
+     * @see Ast#literal(double)
+     */
     public FloatNode(double value) {
         super(value);
     }
 
+    /**
+     * Creates a float literal expression.
+     *
+     * @see Ast#literal(double)
+     */
     public FloatNode(float value) {
         super((double) value);
     }

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/IndexNode.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/IndexNode.java
@@ -11,27 +11,47 @@ import org.quiltmc.chasm.lang.api.eval.Resolver;
 import org.quiltmc.chasm.lang.api.exception.EvaluationException;
 import org.quiltmc.chasm.lang.internal.render.Renderer;
 
+/**
+ * An index expression, e.g. {@code foo[bar]}.
+ */
 public class IndexNode extends Node {
     private Node left;
     private Node index;
 
+    /**
+     * Creates an index expression.
+     *
+     * @see Ast#index(Node, Node)
+     */
     public IndexNode(Node left, Node index) {
         this.left = left;
         this.index = index;
     }
 
+    /**
+     * Gets the subject of this index expression, i.e. the object being indexed into.
+     */
     public Node getLeft() {
         return left;
     }
 
+    /**
+     * Sets the subject of this index expression, i.e. the object being indexed into.
+     */
     public void setLeft(Node node) {
         this.left = node;
     }
 
+    /**
+     * Gets the index.
+     */
     public Node getIndex() {
         return index;
     }
 
+    /**
+     * Gets the index.
+     */
     public void setIndex(Node index) {
         this.index = index;
     }
@@ -55,7 +75,7 @@ public class IndexNode extends Node {
             List<Node> entries = ((ListNode) leftNode).getEntries();
 
             if (index < 0 || index >= entries.size()) {
-                return new NullNode();
+                return NullNode.INSTANCE;
             }
 
             return entries.get((int) index).evaluate(evaluator);
@@ -88,7 +108,7 @@ public class IndexNode extends Node {
             Map<String, Node> entries = ((MapNode) leftNode).getEntries();
 
             if (!entries.containsKey(key)) {
-                return new NullNode();
+                return NullNode.INSTANCE;
             }
 
             return entries.get(key).evaluate(evaluator);

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/IntegerNode.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/IntegerNode.java
@@ -1,10 +1,23 @@
 package org.quiltmc.chasm.lang.api.ast;
 
+/**
+ * An integer literal expression.
+ */
 public class IntegerNode extends ValueNode<Long> {
+    /**
+     * Creates an integer literal expression.
+     *
+     * @see Ast#literal(long)
+     */
     public IntegerNode(long value) {
         super(value);
     }
 
+    /**
+     * Creates an integer literal expression.
+     *
+     * @see Ast#literal(long)
+     */
     public IntegerNode(int value) {
         super((long) value);
     }

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/LambdaNode.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/LambdaNode.java
@@ -5,27 +5,47 @@ import org.quiltmc.chasm.lang.api.eval.Evaluator;
 import org.quiltmc.chasm.lang.api.eval.Resolver;
 import org.quiltmc.chasm.lang.internal.render.Renderer;
 
+/**
+ * A lambda expression.
+ */
 public class LambdaNode extends Node {
     private String identifier;
     private Node inner;
 
+    /**
+     * Creates a lambda expression.
+     *
+     * @see Ast#lambda(String, Node)
+     */
     public LambdaNode(String identifier, Node inner) {
         this.identifier = identifier;
         this.inner = inner;
     }
 
+    /**
+     * Gets the argument name of this lambda expression.
+     */
     public String getIdentifier() {
         return identifier;
     }
 
+    /**
+     * Sets the argument name of this lambda.
+     */
     public void setIdentifier(String identifier) {
         this.identifier = identifier;
     }
 
+    /**
+     * Gets the body of this lambda.
+     */
     public Node getInner() {
         return inner;
     }
 
+    /**
+     * Sets the body of this lambda.
+     */
     public void setInner(Node inner) {
         this.inner = inner;
     }

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/ListNode.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/ListNode.java
@@ -10,13 +10,24 @@ import org.quiltmc.chasm.lang.api.eval.Evaluator;
 import org.quiltmc.chasm.lang.api.eval.Resolver;
 import org.quiltmc.chasm.lang.internal.render.Renderer;
 
+/**
+ * A list expression, for list creation syntax, e.g. {@code [foo, bar, baz]}.
+ */
 public class ListNode extends Node {
     private final List<Node> entries;
 
+    /**
+     * Creates a list expression.
+     *
+     * @see Ast#list()
+     */
     public ListNode(List<Node> entries) {
         this.entries = entries;
     }
 
+    /**
+     * Gets the entries of this list expression.
+     */
     public List<Node> getEntries() {
         return entries;
     }

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/MapNode.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/MapNode.java
@@ -12,13 +12,24 @@ import org.quiltmc.chasm.lang.api.eval.Resolver;
 import org.quiltmc.chasm.lang.internal.render.RenderUtil;
 import org.quiltmc.chasm.lang.internal.render.Renderer;
 
+/**
+ * A map expression, for map creation syntax, e.g. {@code {foo: bar}}.
+ */
 public class MapNode extends Node {
     private final Map<String, Node> entries;
 
+    /**
+     * Creates a map expression.
+     *
+     * @see Ast#map()
+     */
     public MapNode(Map<String, Node> entries) {
         this.entries = entries;
     }
 
+    /**
+     * Gets the entries of this map expression.
+     */
     public Map<String, Node> getEntries() {
         return entries;
     }

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/MemberNode.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/MemberNode.java
@@ -9,27 +9,47 @@ import org.quiltmc.chasm.lang.api.exception.EvaluationException;
 import org.quiltmc.chasm.lang.internal.render.RenderUtil;
 import org.quiltmc.chasm.lang.internal.render.Renderer;
 
+/**
+ * A member access expression, for member syntax for accessing values in a map, e.g. {@code foo.bar}.
+ */
 public class MemberNode extends Node {
     private Node left;
     private String identifier;
 
+    /**
+     * Creates a member access expression.
+     *
+     * @see Ast#member(Node, String)
+     */
     public MemberNode(Node node, String identifier) {
         this.left = node;
         this.identifier = identifier;
     }
 
+    /**
+     * Gets the map from which to get the member.
+     */
     public Node getLeft() {
         return left;
     }
 
+    /**
+     * Sets the map from which to get the member.
+     */
     public void setLeft(Node left) {
         this.left = left;
     }
 
+    /**
+     * Gets the member to extract from the map.
+     */
     public String getIdentifier() {
         return identifier;
     }
 
+    /**
+     * Sets the member to extract from the map.
+     */
     public void setIdentifier(String identifier) {
         this.identifier = identifier;
     }
@@ -58,7 +78,7 @@ public class MemberNode extends Node {
         Map<String, Node> entries = ((MapNode) left).getEntries();
 
         if (!entries.containsKey(identifier)) {
-            return new NullNode();
+            return NullNode.INSTANCE;
         }
 
         return entries.get(identifier).evaluate(evaluator);

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/Node.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/Node.java
@@ -55,6 +55,9 @@ public abstract class Node {
         return parser.file();
     }
 
+    /**
+     * Writes this node to a file.
+     */
     public void write(Path path) throws IOException {
         Renderer renderer = Renderer.builder().build();
         StringBuilder sb = new StringBuilder();

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/NullNode.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/NullNode.java
@@ -1,7 +1,17 @@
 package org.quiltmc.chasm.lang.api.ast;
 
+/**
+ * A null literal expression.
+ */
 public final class NullNode extends ValueNode<Void> {
-    public NullNode() {
+    /**
+     * The expression representing {@code null}.
+     *
+     * @see Ast#nullNode()
+     */
+    public static final NullNode INSTANCE = new NullNode();
+
+    private NullNode() {
         super(null);
     }
 }

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/ReferenceNode.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/ReferenceNode.java
@@ -7,27 +7,52 @@ import org.quiltmc.chasm.lang.api.exception.EvaluationException;
 import org.quiltmc.chasm.lang.internal.render.RenderUtil;
 import org.quiltmc.chasm.lang.internal.render.Renderer;
 
+/**
+ * A reference expression, which loads the value of a symbol ("variable"), e.g. a lambda parameter or a key from an
+ * outer map.
+ */
 public class ReferenceNode extends Node {
     private String identifier;
     private boolean global;
 
+    /**
+     * Creates a reference expression.
+     *
+     * @see Ast#ref(String)
+     * @see Ast#globalRef(String)
+     */
     public ReferenceNode(String identifier, boolean global) {
         this.identifier = identifier;
         this.global = global;
     }
 
+    /**
+     * Gets the reference name.
+     */
     public String getIdentifier() {
         return identifier;
     }
 
+    /**
+     * Sets the reference name.
+     */
     public void setIdentifier(String identifier) {
         this.identifier = identifier;
     }
 
+    /**
+     * Gets whether the reference is global.
+     *
+     * <p>If a reference is global, it is resolved from the outermost scope to the innermost; if a reference is not
+     * global, it is resolved from the innermost scope to the outermost.
+     */
     public boolean isGlobal() {
         return global;
     }
 
+    /**
+     * Sets whether the reference is global. See {@linkplain #isGlobal()} for details.
+     */
     public void setGlobal(boolean global) {
         this.global = global;
     }

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/StringNode.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/StringNode.java
@@ -1,6 +1,14 @@
 package org.quiltmc.chasm.lang.api.ast;
 
+/**
+ * A string literal expression.
+ */
 public final class StringNode extends ValueNode<String> {
+    /**
+     * Creates a string literal expression.
+     *
+     * @see Ast#literal(String)
+     */
     public StringNode(String value) {
         super(value);
     }

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/TernaryNode.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/TernaryNode.java
@@ -6,31 +6,65 @@ import org.quiltmc.chasm.lang.api.eval.Resolver;
 import org.quiltmc.chasm.lang.api.exception.EvaluationException;
 import org.quiltmc.chasm.lang.internal.render.Renderer;
 
+/**
+ * A ternary expression, e.g. {@code foo ? bar : baz}.
+ */
 public class TernaryNode extends Node {
     private Node condition;
     private Node trueExp;
     private Node falseExp;
 
+    /**
+     * Creates a ternary expression.
+     *
+     * @see Ast#ternary(Node, Node, Node)
+     */
     public TernaryNode(Node condition, Node trueExp, Node falseExp) {
         this.condition = condition;
         this.trueExp = trueExp;
         this.falseExp = falseExp;
     }
 
+    /**
+     * Gets the condition.
+     */
     public Node getCondition() {
         return condition;
     }
 
+    /**
+     * Sets the condition.
+     */
     public void setCondition(Node condition) {
         this.condition = condition;
     }
 
+    /**
+     * Gets the expression returned if the condition is true.
+     */
     public Node getTrue() {
         return trueExp;
     }
 
+    /**
+     * Sets the expression returned if the condition is true.
+     */
     public void setTrue(Node trueExp) {
         this.trueExp = trueExp;
+    }
+
+    /**
+     * Gets the expression returned if the condition is false.
+     */
+    public Node getFalse() {
+        return falseExp;
+    }
+
+    /**
+     * Sets the expression returned if the condition is false.
+     */
+    public void setFalse(Node falseExp) {
+        this.falseExp = falseExp;
     }
 
     @Override
@@ -47,14 +81,6 @@ public class TernaryNode extends Node {
         trueExp.render(renderer, builder, currentIndentationMultiplier);
         builder.append(" : ");
         falseExp.render(renderer, builder, currentIndentationMultiplier);
-    }
-
-    public Node getFalse() {
-        return falseExp;
-    }
-
-    public void setFalse(Node falseExp) {
-        this.falseExp = falseExp;
     }
 
     @Override

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/UnaryNode.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/UnaryNode.java
@@ -10,27 +10,47 @@ import org.quiltmc.chasm.lang.api.eval.Resolver;
 import org.quiltmc.chasm.lang.api.exception.EvaluationException;
 import org.quiltmc.chasm.lang.internal.render.Renderer;
 
+/**
+ * A unary operator expression, e.g. {@code -foo}.
+ */
 public class UnaryNode extends Node {
     private Node inner;
     private Operator operator;
 
+    /**
+     * Creates a unary operator expression.
+     *
+     * @see Ast#unary(Operator, Node)
+     */
     public UnaryNode(Node inner, Operator operator) {
         this.inner = inner;
         this.operator = operator;
     }
 
+    /**
+     * Gets the operand.
+     */
     public Node getInner() {
         return inner;
     }
 
+    /**
+     * Sets the operand.
+     */
     public void setInner(Node inner) {
         this.inner = inner;
     }
 
+    /**
+     * Gets the operator.
+     */
     public Operator getOperator() {
         return operator;
     }
 
+    /**
+     * Sets the operator.
+     */
     public void setOperator(Operator operator) {
         this.operator = operator;
     }
@@ -107,10 +127,25 @@ public class UnaryNode extends Node {
         throw new EvaluationException("Can't apply unary operator " + operator + " to " + inner);
     }
 
+    /**
+     * The operator of a unary expression.
+     */
     public enum Operator {
+        /**
+         * The unary plus operator, {@code +}.
+         */
         PLUS("+", 2),
+        /**
+         * The negation operator, {@code -}.
+         */
         MINUS("-", 2),
+        /**
+         * The boolean not operator, {@code !}.
+         */
         NOT("!", 2),
+        /**
+         * The bitwise inversion operator, {@code ~}.
+         */
         INVERT("~", 2);
 
         private final String image;
@@ -128,10 +163,16 @@ public class UnaryNode extends Node {
             this.precedence = precedence;
         }
 
+        /**
+         * The image of this operator, or the string that represents it in code.
+         */
         public String getImage() {
             return image;
         }
 
+        /**
+         * The precedence of the operator, lower values means it's evaluated first by default.
+         */
         public int getPrecedence() {
             return precedence;
         }
@@ -141,6 +182,9 @@ public class UnaryNode extends Node {
             return image;
         }
 
+        /**
+         * Returns whether this operator's precedence is greater than the given value.
+         */
         public boolean morePrecedenceThan(int precedence) {
             return this.precedence > precedence;
         }

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/ValueNode.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/ast/ValueNode.java
@@ -6,17 +6,29 @@ import org.quiltmc.chasm.lang.api.eval.Resolver;
 import org.quiltmc.chasm.lang.internal.render.RenderUtil;
 import org.quiltmc.chasm.lang.internal.render.Renderer;
 
+/**
+ * The base class for literal expressions.
+ */
 public abstract class ValueNode<T> extends Node {
     private T value;
 
+    /**
+     * Creates a literal expression.
+     */
     public ValueNode(T value) {
         this.value = value;
     }
 
+    /**
+     * Gets the value of the literal expression.
+     */
     public T getValue() {
         return value;
     }
 
+    /**
+     * Sets the value of the literal expression.
+     */
     public void setValue(T value) {
         this.value = value;
     }

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/eval/ClosureNode.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/eval/ClosureNode.java
@@ -10,19 +10,30 @@ import org.quiltmc.chasm.lang.api.eval.Resolver;
 import org.quiltmc.chasm.lang.api.exception.EvaluationException;
 import org.quiltmc.chasm.lang.internal.render.Renderer;
 
+/**
+ * Represents a lambda with all captures resolved. Do not create directly; if you really need to create a closure,
+ * use {@linkplain Evaluator#createClosure(LambdaNode)}.
+ */
 public class ClosureNode extends FunctionNode {
     private final LambdaNode lambda;
     private final Map<String, Node> captures;
 
+    @ApiStatus.Internal
     public ClosureNode(LambdaNode lambda, Map<String, Node> captures) {
         this.lambda = lambda;
         this.captures = captures;
     }
 
+    /**
+     * Gets the lambda for this closure.
+     */
     public LambdaNode getLambda() {
         return lambda;
     }
 
+    /**
+     * Gets the captures for this closure.
+     */
     public Map<String, Node> getCaptures() {
         return captures;
     }

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/eval/Evaluator.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/eval/Evaluator.java
@@ -7,28 +7,60 @@ import org.quiltmc.chasm.lang.api.ast.ReferenceNode;
 import org.quiltmc.chasm.lang.internal.eval.EvaluatorImpl;
 import org.quiltmc.chasm.lang.internal.intrinsics.BuiltInIntrinsics;
 
+/**
+ * Helper for evaluating (reducing) nodes.
+ */
 @ApiStatus.NonExtendable
 public interface Evaluator {
+    /**
+     * Creates an evaluator with the default settings for the given root node.
+     */
     static Evaluator create(Node node) {
         return new EvaluatorImpl(node, BuiltInIntrinsics.ALL);
     }
 
+    /**
+     * Creates an evaluator builder for the given root node, with which you can customize the evaluator's settings.
+     */
     static Builder builder(Node node) {
         return new EvaluatorImpl.Builder(node);
     }
 
+    /**
+     * Resolves a reference node to the node it is referring to.
+     */
     Node resolveReference(ReferenceNode reference);
 
+    /**
+     * Creates a closure from a lambda node.
+     *
+     * @see ClosureNode
+     */
     ClosureNode createClosure(LambdaNode lambdaNode);
 
+    /**
+     * Applies a closure using the given argument.
+     */
     Node callClosure(ClosureNode closure, Node arg);
 
+    /**
+     * Gets the {@linkplain Resolver} of this evaluator.
+     */
     Resolver getResolver();
 
+    /**
+     * An evaluator builder to customize the settings of an evaluator.
+     */
     @ApiStatus.NonExtendable
     interface Builder {
+        /**
+         * Adds a new intrinsic function.
+         */
         Builder addIntrinsic(IntrinsicFunction intrinsic);
 
+        /**
+         * Builds the evaluator.
+         */
         Evaluator build();
     }
 }

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/eval/FunctionNode.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/eval/FunctionNode.java
@@ -2,7 +2,13 @@ package org.quiltmc.chasm.lang.api.eval;
 
 import org.quiltmc.chasm.lang.api.ast.Node;
 
+/**
+ * The base class for any node that can be applied using a call expression (a "function").
+ */
 public abstract class FunctionNode extends Node {
+    /**
+     * Applies the function using the given argument.
+     */
     public abstract Node apply(Evaluator evaluator, Node arg);
 
     @Override

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/eval/IntrinsicFunction.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/eval/IntrinsicFunction.java
@@ -2,7 +2,14 @@ package org.quiltmc.chasm.lang.api.eval;
 
 import org.quiltmc.chasm.lang.internal.render.Renderer;
 
+/**
+ * A function that is implemented in Java rather than in chassembly. Some built-in intrinsic functions may also be
+ * treated specially by the evaluator as well.
+ */
 public abstract class IntrinsicFunction extends FunctionNode {
+    /**
+     * Returns the name of the intrinsic function.
+     */
     public abstract String getName();
 
     @Override

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/eval/Resolver.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/eval/Resolver.java
@@ -5,15 +5,33 @@ import org.quiltmc.chasm.lang.api.ast.LambdaNode;
 import org.quiltmc.chasm.lang.api.ast.MapNode;
 import org.quiltmc.chasm.lang.api.ast.ReferenceNode;
 
+/**
+ * A helper for resolving which node chassembly references refer to.
+ */
 @ApiStatus.NonExtendable
 public interface Resolver {
+    /**
+     * Resolves the reference and stores the result in this resolver, so that it can be queried later by the evaluator.
+     */
     void resolveReference(ReferenceNode reference);
 
+    /**
+     * Enters a map scope.
+     */
     void enterMap(MapNode map);
 
+    /**
+     * Exits a map scope.
+     */
     void exitMap();
 
+    /**
+     * Enters a lambda scope.
+     */
     void enterLambda(LambdaNode lambda);
 
+    /**
+     * Exits a lambda scope.
+     */
     void exitLambda();
 }

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/exception/EvaluationException.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/exception/EvaluationException.java
@@ -1,6 +1,12 @@
 package org.quiltmc.chasm.lang.api.exception;
 
+/**
+ * Thrown when chassembly evaluation fails.
+ */
 public class EvaluationException extends RuntimeException {
+    /**
+     * Creates an {@linkplain EvaluationException} with the given message.
+     */
     public EvaluationException(String message) {
         super(message);
     }

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/api/exception/ParseException.java
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/api/exception/ParseException.java
@@ -1,4 +1,7 @@
 package org.quiltmc.chasm.lang.api.exception;
 
+/**
+ * Thrown when a piece of chassembly code failed to parse.
+ */
 public class ParseException extends RuntimeException {
 }

--- a/chassembly/src/main/java/org/quiltmc/chasm/lang/internal/parse/Parser.jj
+++ b/chassembly/src/main/java/org/quiltmc/chasm/lang/internal/parse/Parser.jj
@@ -67,7 +67,7 @@ Node literalExpression():
 {
     (
         t = <NullLiteral>
-        { n = new NullNode(); }
+        { n = NullNode.INSTANCE; }
         |
         t = <BooleanLiteral>
         { n = BooleanNode.from(Boolean.parseBoolean(t.getImage())); }

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -8,7 +8,6 @@
     - Doubled indents
     - 120 line length limit
     - Import order
-    - suppressions.xml
  -->
 
 <!--
@@ -51,6 +50,11 @@
         <property name="fileExtensions" value="java"/>
         <property name="max" value="120"/>
         <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+    </module>
+
+    <module name="SuppressionSingleFilter">
+        <property name="files" value=".*[/\\](internal|test).*[/\\]"/>
+        <property name="checks" value="MissingJavadoc.*"/>
     </module>
 
     <module name="TreeWalker">
@@ -324,7 +328,6 @@
                       value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
         </module>
         <module name="JavadocMethod">
-            <property name="severity" value="warning"/>
             <property name="accessModifiers" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
@@ -332,7 +335,6 @@
             <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF"/>
         </module>
         <module name="MissingJavadocMethod">
-            <property name="severity" value="warning"/>
             <property name="scope" value="public"/>
             <property name="minLineCount" value="2"/>
             <property name="allowedAnnotations" value="Override, Test"/>
@@ -340,7 +342,6 @@
                                    COMPACT_CTOR_DEF"/>
         </module>
         <module name="MissingJavadocType">
-            <property name="severity" value="warning"/>
             <property name="scope" value="protected"/>
             <property name="tokens"
                       value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,


### PR DESCRIPTION
… add missing Javadocs elsewhere.

Closes #88 

Also replaced `NullNode` instances with a singleton, like `BooleanNode` already has two singletons. Should save a tiny bit of memory.