### PR TITLE
Ignore parameter debug names for now

### DIFF
--- a/chasm/src/main/java/org/quiltmc/chasm/internal/asm/visitor/ChasmMethodVisitor.java
+++ b/chasm/src/main/java/org/quiltmc/chasm/internal/asm/visitor/ChasmMethodVisitor.java
@@ -103,11 +103,14 @@ public class ChasmMethodVisitor extends MethodVisitor {
 
     @Override
     public void visitParameter(String name, int access) {
+        // TODO: Add debug information elsewhere
+        /*
         MapNode parameterNode = (MapNode) this.parameters.getEntries().get(visitedParameterCount++);
         if (name != null) {
             parameterNode.getEntries().put(NodeConstants.NAME, new StringNode(name));
         }
         parameterNode.getEntries().put(NodeConstants.ACCESS, new IntegerNode(access));
+        */
         super.visitParameter(name, access);
     }
 

--- a/chasm/src/testData/results/unchanged/ExampleClass$ExampleRecord.result
+++ b/chasm/src/testData/results/unchanged/ExampleClass$ExampleRecord.result
@@ -20,17 +20,17 @@ public final class other/ExampleClass$ExampleRecord extends java/lang/Record {
 
   // access flags 0x1
   public <init>(Ljava/lang/Integer;Ljava/lang/String;)V
-    // parameter  first
-    // parameter  second
+    // parameter  P0
+    // parameter  P1
    L0
     LINENUMBER 80 L0
     ALOAD 0
     INVOKESPECIAL java/lang/Record.<init> ()V
     ALOAD 0
-    ALOAD 3
+    ALOAD 1
     PUTFIELD other/ExampleClass$ExampleRecord.first : Ljava/lang/Integer;
     ALOAD 0
-    ALOAD 4
+    ALOAD 2
     PUTFIELD other/ExampleClass$ExampleRecord.second : Ljava/lang/String;
     RETURN
    L1
@@ -38,7 +38,7 @@ public final class other/ExampleClass$ExampleRecord extends java/lang/Record {
     LOCALVARIABLE first Ljava/lang/Integer; L0 L1 1
     LOCALVARIABLE second Ljava/lang/String; L0 L1 2
     MAXSTACK = 2
-    MAXLOCALS = 5
+    MAXLOCALS = 3
 
   // access flags 0x11
   public final toString()Ljava/lang/String;


### PR DESCRIPTION
This currently causes verifier errors since the names in the parameters don't match the local variable isntructions.
Revisit a proper solution together with #93 
