### PR TITLE
Run the build task for merge groups

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: Test and Build
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  merge_group:
 
 jobs:
   build:


### PR DESCRIPTION
I want to enable and require the new merge queue feature for the main branch.
This requires to have checks also run on `merge_queue`.
for more info, see here: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions